### PR TITLE
display help message when called without arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,11 @@ import (
 func main() {
 	var c cmd.Command
 
+	if len(os.Args) == 1 {
+		cmd.NewHelpCommand().Execute()
+		os.Exit(1)
+	}
+
 	switch os.Args[1] {
 	case "version":
 		c = cmd.NewVersionCommand()


### PR DESCRIPTION
As a new user to microcks-cli, when I call `microcks-cli` without argument, it crashes:

```raw
$ ./microcks-cli 
panic: runtime error: index out of range

goroutine 1 [running]:
main.main()
	/Users/lbroudou/Development/github/microcks-cli/main.go:12 +0x129
```

This PR is about printing the help message when the user calls microcks-cli without argument. 
