### PR TITLE
Add support for URLs in import command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Ouput of the build-binaries script
 build/_output
+
+# .DS_Store file of MacOS
+.DS_Store

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -40,6 +40,7 @@ func (c *helpCommand) Execute() {
 	fmt.Println("  help        display this help message")
 	fmt.Println("  test        launch new test on Microcks server")
 	fmt.Println("  import      import API artifacts on Microcks server")
+	fmt.Println("  import-url  import API artifacts from URL on Microcks server")
 	fmt.Println("")
 	fmt.Println("Use: microcks-cli test <apiName:apiVersion> <testEndpoint> <runner> \\")
 	fmt.Println("   --microcksURL=<> --waitFor=5sec \\")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -118,7 +118,7 @@ func (c *importComamnd) Execute() {
 		mainArtifact := true
 
 		// Check if mainArtifact flag is provided.
-		if strings.Contains(f, ":") {
+		if strings.Contains(f, ":") && !(strings.HasPrefix(f, "http://") || strings.HasPrefix(f, "https://")) {
 			pathAndMainArtifact := strings.Split(f, ":")
 			f = pathAndMainArtifact[0]
 			mainArtifact, err = strconv.ParseBool(pathAndMainArtifact[1])

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/microcks/microcks-cli/pkg/config"
+	"github.com/microcks/microcks-cli/pkg/connectors"
+)
+
+type importURLCommand struct {
+}
+
+func NewImportURLCommand() Command {
+	return new(importURLCommand)
+}
+
+func (c *importURLCommand) Execute() {
+	// Parse subcommand args first.
+	if len(os.Args) < 2 {
+		fmt.Println("import-url command require <specificationFile1URL[:primary],specificationFile2URL[:primary]> args")
+		os.Exit(1)
+	}
+
+	specificationFiles := os.Args[2]
+
+	// Then parse flags.
+	importCmd := flag.NewFlagSet("import-url", flag.ExitOnError)
+
+	var microcksURL string
+	var keycloakURL string
+	var keycloakClientID string
+	var keycloakClientSecret string
+	var insecureTLS bool
+	var caCertPaths string
+	var verbose bool
+
+	importCmd.StringVar(&microcksURL, "microcksURL", "", "Microcks API URL")
+	importCmd.StringVar(&keycloakClientID, "keycloakClientId", "", "Keycloak Realm Service Account ClientId")
+	importCmd.StringVar(&keycloakClientSecret, "keycloakClientSecret", "", "Keycloak Realm Service Account ClientSecret")
+	importCmd.BoolVar(&insecureTLS, "insecure", false, "Whether to accept insecure HTTPS connection")
+	importCmd.StringVar(&caCertPaths, "caCerts", "", "Comma separated paths of CRT files to add to Root CAs")
+	importCmd.BoolVar(&verbose, "verbose", false, "Produce dumps of HTTP exchanges")
+	importCmd.Parse(os.Args[3:])
+
+	// Validate presence and values of flags.
+	if len(microcksURL) == 0 {
+		fmt.Println("--microcksURL flag is mandatory. Check Usage.")
+		os.Exit(1)
+	}
+	if len(keycloakClientID) == 0 {
+		fmt.Println("--keycloakClientId flag is mandatory. Check Usage.")
+		os.Exit(1)
+	}
+	if len(keycloakClientSecret) == 0 {
+		fmt.Println("--keycloakClientSecret flag is mandatory. Check Usage.")
+		os.Exit(1)
+	}
+
+	// Collect optional HTTPS transport flags.
+	if insecureTLS {
+		config.InsecureTLS = true
+	}
+	if len(caCertPaths) > 0 {
+		config.CaCertPaths = caCertPaths
+	}
+	if verbose {
+		config.Verbose = true
+	}
+
+	// Now we seems to be good ...
+	// First - retrieve the Keycloak URL from Microcks configuration.
+	mc := connectors.NewMicrocksClient(microcksURL)
+	keycloakURL, err := mc.GetKeycloakURL()
+	if err != nil {
+		fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
+		os.Exit(1)
+	}
+
+	var oauthToken string = "unauthentifed-token"
+	if keycloakURL != "null" {
+		//  If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
+		kc := connectors.NewKeycloakClient(keycloakURL, keycloakClientID, keycloakClientSecret)
+
+		oauthToken, err = kc.ConnectAndGetToken()
+		if err != nil {
+			fmt.Printf("Got error when invoking Keycloack client: %s", err)
+			os.Exit(1)
+		}
+	}
+
+	// Then - for each specificationFile, upload the artifact on Microcks Server.
+	mc.SetOAuthToken(oauthToken)
+
+	sepSpecificationFiles := strings.Split(specificationFiles, ",")
+	for _, f := range sepSpecificationFiles {
+		mainArtifact := true
+		secret := ""
+
+		// Check if URL starts with https or http
+		if strings.HasPrefix(f, "https://") || strings.HasPrefix(f, "http://") {
+			urlAndMainAtrifactAndSecretName := strings.Split(f, ":")
+			n := len(urlAndMainAtrifactAndSecretName)
+			f = urlAndMainAtrifactAndSecretName[0] + ":" + urlAndMainAtrifactAndSecretName[1]
+			if n > 2 {
+				val, err := strconv.ParseBool(urlAndMainAtrifactAndSecretName[2])
+				if err != nil {
+					fmt.Println(err)
+				}
+				mainArtifact = val
+			}
+			if n > 3 {
+				secret = urlAndMainAtrifactAndSecretName[3]
+			}
+		}
+
+		// Try downloading the artifcat
+		msg, err := mc.DownloadArtifact(f, mainArtifact, secret)
+		if err != nil {
+			fmt.Printf("Got error when invoking Microcks client importing Artifact: %s", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Microcks has discovered '%s'\n", msg)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ func main() {
 		c = cmd.NewTestCommand()
 	case "import":
 		c = cmd.NewImportCommand()
+	case "import-url":
+		c = cmd.NewImportURLCommand()
 	default:
 		cmd.NewHelpCommand().Execute()
 		os.Exit(1)

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -44,6 +44,7 @@ type MicrocksClient interface {
 	CreateTestResult(serviceID string, testEndpoint string, runnerType string, secretName string, timeout int64, filteredOperations string, operationsHeaders string, oAuth2Context string) (string, error)
 	GetTestResult(testResultID string) (*TestResultSummary, error)
 	UploadArtifact(specificationFilePath string, mainArtifact bool) (string, error)
+	DownloadArtifact(artifactURL string, mainArtifact bool, secret string) (string, error)
 }
 
 // TestResultSummary represents a simple view on Microcks TestResult


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR adds support for URLs in `import` command.
- Now `microcks-cli` is able to fetch artifacts or specification file from the URL and import it into the Microcks.

**As of now, we can only import artifacts from the URL as a primary artifact.

### Changes

- Updated `UploadArtifact` function of `MicrocksClient`.
- Updated `ImportCommand` which will accept artifact from URL as a Primary Artifact.
- `ioutil.ReadAll()` is deprecated, which is replaced by `io.ReadAll`.

### Related issue(s)
Resolves #80 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->