### PR TITLE
Generate Brew Formula and SBOM thanks to Goreleaser

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -3,16 +3,16 @@ on:
   push:
     paths-ignore:
       #- '.github/**'
-      - '.gitignore'
-      - 'LICENSE'
-      - '*.md'
+      - ".gitignore"
+      - "LICENSE"
+      - "*.md"
   pull_request:
     paths-ignore:
-      - '.github/**'
-      - '.gitignore'
-      - 'LICENSE'
-      - '*.md'
-permissions: 
+      - ".github/**"
+      - ".gitignore"
+      - "LICENSE"
+      - "*.md"
+permissions:
   contents: read
   id-token: write # needed for signing the images with GitHub OIDC Token
 
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.3'
+          go-version: "1.21.3"
 
       - name: Build Go packages
         run: |

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,30 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "${{ env.GITHUB_REF_NAME }}"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,23 @@
+version: 2
+
+builds:
+  - main: ./main.go
+    binary: microcks-cli
+    env:
+      - CGO_ENABLED=0
+
+release:
+  prerelease: auto
+
+universal_binaries:
+  - replace: true
+
+brews:
+  - name: microcks-cli
+    homepage: https://github.com/microcks/microcks-cli
+    repository:
+      owner: microcks
+      name: homebrew-tap
+
+checksum:
+  name_template: "checksums.txt"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,5 +19,8 @@ brews:
       owner: microcks
       name: homebrew-tap
 
+sboms:
+  - artifacts: archive
+
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
### Description

I believe I have completed the first version of the `.goreleaser.yaml` file, which will publish a Homebrew Formula based on the released version.

The next steps are:

- You'll need to create a repository named `microcks/homebrew-tap` (this name is mandatory!), which will serve as the reference for microcks-cli. This repository will be automatically updated by Goreleaser with each new release.
- You'll need to create a Personal Access Token with repo authorization and refer it on `microcks/microcks-cli` repository.

I have also explored creating or updating an `apt repository`, but it appears to be far more complex than Homebrew, so Goreleaser does not currently handle it. (See [this issue](https://github.com/goreleaser/goreleaser/issues/912))

Some helpful links:
[Goreleaser documentation for creating Homebrew formulas](https://goreleaser.com/customization/homebrew/)
[Goreleaser documentation for generating SBOM](https://goreleaser.com/customization/sbom/#usage)

### Related issue(s)

See #89 and #90 