### PR TITLE
Start and Stop command using cobra cli

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+  "fmt"
+  "os"
+  "github.com/spf13/cobra"
+)
+
+//rootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "microcks-cli",
+  Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	// Run: func(cmd *cobra.Command, args []string) { },
+}
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+    os.Exit(1)
+	}
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var startCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the Microcks server",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Starting Microcks server...")
+
+		startCmd := exec.Command("docker", "run", "-d", "-p", "8585:8080", "--rm", "--name", "microcks-server", "quay.io/microcks/microcks-uber:latest-native")
+
+		startCmd.Stdout = nil
+		startCmd.Stderr = os.Stderr
+
+		if err := startCmd.Run(); err != nil {
+			fmt.Printf("Error starting Microcks: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(startCmd)
+}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var stopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the Microcks server",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Stopping Microcks server...")
+
+		stopCmd := exec.Command("docker", "stop", "microcks-server")
+
+		stopCmd.Stdout = cmd.OutOrStdout()
+		stopCmd.Stderr = cmd.OutOrStderr()
+
+		if err := stopCmd.Run(); err != nil {
+			fmt.Printf("Error stopping Microcks: %v\n", err)
+		} else {
+			fmt.Println("Microcks server stopped.")
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(stopCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/microcks/microcks-cli
 
 go 1.21.3
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.9.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.0 h1:Py5fIuq/lJsRYxcxfOtsJqpmwJWCMOUy2tMJYV8TNHE=
+github.com/spf13/cobra v1.9.0/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -13,6 +13,11 @@ func main() {
 		cmd.NewHelpCommand().Execute()
 		os.Exit(1)
 	}
+ //  start and stop command using cobra by preventing overwriting of the previous command
+  if os.Args[1] == "start" || os.Args[1] == "stop" {
+    cmd.Execute()
+    return
+  }
 
 	switch os.Args[1] {
 	case "version":


### PR DESCRIPTION
Adding the start and stop commands for microcks-cli using cobra cli. The modules have also been updated

microcks-cli start : Starts the server in the background by pulling the docker image with the container name "microcks-server"

microcks-cli stop: Stops the  server. 

Also updated main.go to prevent overwriting the existing commands. 

Future implementation:
Adding viper for managing configuration, for example allowing the users to select the port to run the microcks server.
Migrating the other commands into cobra cli for easy management. Cobra cli generates a help page based on the commands built without even need for building the help command.

