### PR TITLE
Enhance GoReleaser config with multi-platform builds, release customizations, and changelog filters

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,13 +1,42 @@
 version: 2
+project_name: microcks-cli
+
+before: 
+  hooks:
+    - go mod tidy
 
 builds:
   - main: ./main.go
     binary: microcks-cli
     env:
       - CGO_ENABLED=0
+    goos: 
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+
+archives:
+- format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
 
 release:
+  name_template: "Microcks CLI v{{.Tag}}"
+  draft: true
+  disable: false
   prerelease: auto
+  github:
+    owner: microcks
+    name: microcks-cli
 
 universal_binaries:
   - replace: true
@@ -36,3 +65,11 @@ sboms:
 
 checksum:
   name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters: 
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - typo


### PR DESCRIPTION
This PR updates the GoReleaser config to support:

1. Multi-platform builds (linux, darwin, windows) and multiple architectures (amd64, arm64).
2. Custom archive formats (tar.gz for most, zip for Windows).
3. A before hook to run go mod tidy before builds.
4. A release name template for better versioning.
5. Changelog filters to exclude commit types like docs, tests, and typos.