### PR TITLE
feat: add homebrew tap formula for microcks

### DIFF
--- a/homebrew-tap/microcks.rb
+++ b/homebrew-tap/microcks.rb
@@ -1,0 +1,20 @@
+class Microcks < Formula
+    desc "Simple CLI for interacting with Microcks test APIs"
+    homepage "https://github.com/microcks/microcks-cli"
+    url "https://github.com/microcks/microcks-cli/archive/refs/tags/0.5.7.tar.gz"
+    sha256 "be49890c386736def0ba2ce1ddc002d49efaad04cc06188cd7f27593096274ea"
+    license "Apache-2.0"
+  
+    depends_on "go" => :build
+  
+    def install
+      ENV["CGO_ENABLED"] = "0"
+
+      system "go", "build", "./main.go"    
+    end
+  
+    test do 
+        
+    end
+  
+  end


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
I have created a Homebrew formula for Microcks CLI and propose creating a new repository named `'homebrew-tap' `under the `Microcks organization.` This will allow users to easily install Microcks using the `Homebrew` package manager with a simple brew install microcks command, following common practices from other open-source projects.


Todo -

- [ ] Add microcks.rb to homebrew-tap repository to enable Homebrew installation.

@yada @lbroudoux 
