### PR TITLE
Remove unnecessary checks for flags

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -41,26 +41,12 @@ func NewImportCommand() *cobra.Command {
 		Long:  `import API artifacts on Microcks server`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Parse subcommand args first.
-			if len(os.Args) < 2 {
+			if len(args) == 0 {
 				fmt.Println("import command require <specificationFile1[:primary],specificationFile2[:primary]> args")
 				os.Exit(1)
 			}
 
-			specificationFiles := os.Args[2]
-
-			// Validate presence and values of flags.
-			if len(microcksURL) == 0 {
-				fmt.Println("--microcksURL flag is mandatory. Check Usage.")
-				os.Exit(1)
-			}
-			if len(keycloakClientID) == 0 {
-				fmt.Println("--keycloakClientId flag is mandatory. Check Usage.")
-				os.Exit(1)
-			}
-			if len(keycloakClientSecret) == 0 {
-				fmt.Println("--keycloakClientSecret flag is mandatory. Check Usage.")
-				os.Exit(1)
-			}
+			specificationFiles := args[0]
 
 			// Collect optional HTTPS transport flags.
 			if insecureTLS {
@@ -128,5 +114,11 @@ func NewImportCommand() *cobra.Command {
 	importCmd.Flags().BoolVar(&insecureTLS, "insecure", false, "Whether to accept insecure HTTPS connection")
 	importCmd.Flags().StringVar(&caCertPaths, "caCerts", "", "Comma separated paths of CRT files to add to Root CAs")
 	importCmd.Flags().BoolVar(&verbose, "verbose", false, "Produce dumps of HTTP exchanges")
+
+	//Marking flags 'required'
+	importCmd.MarkFlagRequired("microcksURL")
+	importCmd.MarkFlagRequired("keycloakClientId")
+	importCmd.MarkFlagRequired("keycloakClientSecret")
+
 	return importCmd
 }

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -27,20 +27,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// import (
-// 	"flag"
-// 	"fmt"
-// 	"os"
-// 	"strconv"
-// 	"strings"
-
-// 	"github.com/microcks/microcks-cli/pkg/config"
-// 	"github.com/microcks/microcks-cli/pkg/connectors"
-// )
-
-// type importURLCommand struct {
-// }
-
 func NewImportURLCommand() *cobra.Command {
 	var (
 		microcksURL          string
@@ -56,26 +42,12 @@ func NewImportURLCommand() *cobra.Command {
 		Long:  `import API artifacts from URL on Microcks server`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Parse subcommand args first.
-			if len(os.Args) < 2 {
+			if len(args) == 0 {
 				fmt.Println("import-url command require <specificationFile1URL[:primary],specificationFile2URL[:primary]> args")
 				os.Exit(1)
 			}
 
 			specificationFiles := os.Args[2]
-
-			// Validate presence and values of flags.
-			if len(microcksURL) == 0 {
-				fmt.Println("--microcksURL flag is mandatory. Check Usage.")
-				os.Exit(1)
-			}
-			if len(keycloakClientID) == 0 {
-				fmt.Println("--keycloakClientId flag is mandatory. Check Usage.")
-				os.Exit(1)
-			}
-			if len(keycloakClientSecret) == 0 {
-				fmt.Println("--keycloakClientSecret flag is mandatory. Check Usage.")
-				os.Exit(1)
-			}
 
 			// Collect optional HTTPS transport flags.
 			if insecureTLS {
@@ -150,6 +122,11 @@ func NewImportURLCommand() *cobra.Command {
 	importURLCmd.Flags().BoolVar(&insecureTLS, "insecure", false, "Whether to accept insecure HTTPS connection")
 	importURLCmd.Flags().StringVar(&caCertPaths, "caCerts", "", "Comma separated paths of CRT files to add to Root CAs")
 	importURLCmd.Flags().BoolVar(&verbose, "verbose", false, "Produce dumps of HTTP exchanges")
+
+	//Marking flags 'required'
+	importURLCmd.MarkFlagRequired("microcksURL")
+	importURLCmd.MarkFlagRequired("keycloakClientId")
+	importURLCmd.MarkFlagRequired("keycloakClientSecret")
 
 	return importURLCmd
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -81,18 +81,6 @@ func NewTestCommand() *cobra.Command {
 			}
 
 			// Validate presence and values of flags.
-			if len(microcksURL) == 0 {
-				fmt.Println("--microcksURL flag is mandatory. Check Usage.")
-				os.Exit(1)
-			}
-			if len(keycloakClientID) == 0 {
-				fmt.Println("--keycloakClientId flag is mandatory. Check Usage.")
-				os.Exit(1)
-			}
-			if len(keycloakClientSecret) == 0 {
-				fmt.Println("--keycloakClientSecret flag is mandatory. Check Usage.")
-				os.Exit(1)
-			}
 			if &waitFor == nil || (!strings.HasSuffix(waitFor, "milli") && !strings.HasSuffix(waitFor, "sec") && !strings.HasSuffix(waitFor, "min")) {
 				fmt.Println("--waitFor format is wrong. Applying default 5sec")
 				waitFor = "5sec"
@@ -199,6 +187,11 @@ func NewTestCommand() *cobra.Command {
 	testCmd.Flags().BoolVar(&insecureTLS, "insecure", false, "Whether to accept insecure HTTPS connection")
 	testCmd.Flags().StringVar(&caCertPaths, "caCerts", "", "Comma separated paths of CRT files to add to Root CAs")
 	testCmd.Flags().BoolVar(&verbose, "verbose", false, "Produce dumps of HTTP exchanges")
+
+	//Marking flags 'required'
+	testCmd.MarkFlagRequired("microcksURL")
+	testCmd.MarkFlagRequired("keycloakClientId")
+	testCmd.MarkFlagRequired("keycloakClientSecret")
 
 	return testCmd
 }


### PR DESCRIPTION
### Description

- There were some checks for flags, which are removed and replace by existing functionality of `cobra.Command` and now there is no more headache to check it manually.

### Related issue(s)
Resolves #128 
