### PR TITLE
Feat: Add 'watch' flag to `import` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,7 @@ build-binaries:
 	make BIN_NAME=${CLI_NAME}-darwin-arm64 GOOS=darwin GOARCH=arm64 build-local
 	make BIN_NAME=${CLI_NAME}-windows-amd64.exe GOOS=windows build-local
 	make BIN_NAME=${CLI_NAME}-windows-386.exe GOOS=windows GOARCH=386 build-local
+
+.PHONY: build-watcher
+build-watcher:
+	go build -o ${DIST_DIR}/${BIN_NAME}-${WATCHER_NAME} ${PACKAGE}/pkg/importer

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -63,7 +63,7 @@ microcks context httP://localhost:8080 --delete`,
 		},
 	}
 
-	ctxCmd.Flags().BoolVar(&delete, "delete", false, "Delete a context")
+	ctxCmd.Flags().BoolVarP(&delete, "delete", "d", false, "Delete a context")
 
 	return ctxCmd
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -23,10 +23,13 @@ import (
 
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
+	"github.com/microcks/microcks-cli/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
+	var watch bool
+
 	var importCmd = &cobra.Command{
 		Use:   "import",
 		Short: "import API artifacts on Microcks server",
@@ -35,6 +38,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 			// Parse subcommand args first.
 			if len(args) == 0 {
 				fmt.Println("import command require <specificationFile1[:primary],specificationFile2[:primary]> args")
+				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
 
@@ -53,6 +57,10 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 			if localConfig == nil {
 				fmt.Println("Please login to perform opertion...")
 				return
+			}
+
+			if globalClientOpts.Context == "" {
+				globalClientOpts.Context = localConfig.CurrentContext
 			}
 
 			mc, err := connectors.NewClient(*globalClientOpts)
@@ -82,10 +90,33 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 					os.Exit(1)
 				}
 				fmt.Printf("Microcks has discovered '%s'\n", msg)
+
+				if watch {
+					watchFile, err := config.DefaultLocalWatchPath()
+					errors.CheckError(err)
+					watchCfg, err := config.ReadLocalWatchConfig(watchFile)
+					errors.CheckError(err)
+					if watchCfg == nil {
+						watchCfg = &config.WatchConfig{}
+					}
+
+					watchCfg.UpsertEntry(config.WatchEntry{
+						FilePath:     f,
+						Context:      []string{globalClientOpts.Context},
+						MainArtifact: mainArtifact,
+					})
+
+					fmt.Println(watchCfg.Entries)
+
+					//write watch file
+					err = config.WriteLocalWatchConfig(*watchCfg, watchFile)
+					errors.CheckError(err)
+				}
 			}
 
 		},
 	}
 
+	importCmd.Flags().BoolVar(&watch, "watch", false, "Keep watch on file changes and re-import it on change	")
 	return importCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/docker/docker v28.0.4+incompatible
 	github.com/docker/go-connections v0.5.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
 github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/pkg/importer/main.go
+++ b/pkg/importer/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/microcks/microcks-cli/pkg/config"
+	"github.com/microcks/microcks-cli/pkg/errors"
+	"github.com/microcks/microcks-cli/pkg/importer/watcher"
+)
+
+func main() {
+	watchFile, err := config.DefaultLocalWatchPath()
+	errors.CheckError(err)
+
+	wm, err := watcher.NewWatchManger(watchFile)
+	errors.CheckError(err)
+
+	fmt.Println("[INFO] microcks-watcher started...")
+	wm.Run()
+}

--- a/pkg/importer/watcher/executor.go
+++ b/pkg/importer/watcher/executor.go
@@ -1,0 +1,51 @@
+package watcher
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/microcks/microcks-cli/cmd"
+	"github.com/microcks/microcks-cli/pkg/config"
+	"github.com/microcks/microcks-cli/pkg/connectors"
+)
+
+func TriggerImport(entry config.WatchEntry) {
+	mainArtifact := strconv.FormatBool(entry.MainArtifact)
+
+	args := []string{
+		entry.FilePath + ":" + mainArtifact,
+	}
+
+	cfgPath, err := config.DefaultLocalConfigPath()
+	if err != nil {
+		fmt.Errorf("Error while loading config: %s", err.Error())
+	}
+
+	for _, context := range entry.Context {
+		importCommand := cmd.NewImportCommand(&connectors.ClientOptions{
+			ConfigPath: cfgPath,
+			Context:    context,
+		})
+		importCommand.SetArgs(args)
+		err = importCommand.Execute()
+		if err != nil {
+			fmt.Printf("Error re-importing %s: %v\n", entry.FilePath, err)
+		}
+
+		fmt.Printf("Imported '%s' in context '%s'\n", entry.FilePath, context)
+	}
+}
+
+func LoadRegistry(watchFilePath string) (*config.WatchConfig, error) {
+	var watchCfg *config.WatchConfig
+	watchCfg, err := config.ReadLocalWatchConfig(watchFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if watchCfg == nil {
+		watchCfg = &config.WatchConfig{}
+	}
+
+	return watchCfg, nil
+}

--- a/pkg/importer/watcher/watchManager.go
+++ b/pkg/importer/watcher/watchManager.go
@@ -1,0 +1,105 @@
+package watcher
+
+import (
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/microcks/microcks-cli/pkg/config"
+	"github.com/microcks/microcks-cli/pkg/errors"
+)
+
+type WatchManager struct {
+	fileWatcher  *fsnotify.Watcher
+	configPath   string
+	watchEntries map[string]config.WatchEntry
+	lock         sync.Mutex
+}
+
+func NewWatchManger(configPath string) (*WatchManager, error) {
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	err = fw.Add(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	wm := &WatchManager{
+		fileWatcher:  fw,
+		configPath:   configPath,
+		watchEntries: make(map[string]config.WatchEntry),
+	}
+
+	err = wm.Reload()
+	if err != nil {
+		return nil, err
+	}
+
+	return wm, nil
+}
+
+func (wm *WatchManager) Reload() error {
+	cfg, err := LoadRegistry(wm.configPath)
+	if err != nil {
+		return err
+	}
+
+	newFiles := map[string]config.WatchEntry{}
+	for _, entry := range cfg.Entries {
+		newFiles[entry.FilePath] = entry
+	}
+
+	// Remove stale watchers
+	for file := range wm.watchEntries {
+		if _, exists := newFiles[file]; !exists {
+			wm.fileWatcher.Remove(file)
+		}
+	}
+
+	// Add new watchers
+	for file := range newFiles {
+		if _, exists := wm.watchEntries[file]; !exists {
+			err := wm.fileWatcher.Add(file)
+			if err != nil {
+				log.Printf("[WARN] Cannot watch file %s: %v", file, err)
+				continue
+			}
+		}
+	}
+
+	wm.watchEntries = newFiles
+	fmt.Println(wm.watchEntries)
+	return nil
+}
+
+func (wm *WatchManager) Run() {
+	for {
+		select {
+		case event := <-wm.fileWatcher.Events:
+			if event.Op&fsnotify.Write == fsnotify.Write {
+				if event.Name == wm.configPath {
+					fmt.Println("[INFO] Reloading config...")
+					wm.lock.Lock()
+					err := wm.Reload()
+					wm.lock.Unlock()
+					if err != nil {
+						errors.CheckError(err)
+					}
+				} else {
+					wm.lock.Lock()
+					entry, exists := wm.watchEntries[event.Name]
+					wm.lock.Unlock()
+					if exists {
+						go TriggerImport(entry)
+					}
+				}
+			}
+		case err := <-wm.fileWatcher.Errors:
+			log.Printf("[ERROR] Watcher error: %v", err)
+		}
+	}
+}


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR adds support for `watch` flag in `import` command.
- It allows user to import a local files to microcks instance and keep watch on them. On file change, files will automatically get re-imported.
- To keep track of files, we have added a separate program called `microcks-watcher`. You can build the binary of the `microcks-watcher` using `make build-watcher`.
- It will keep checking for changes in `WatchConfig` as well as all the files listed in this config.
- On changes in `WatchConfig` it can auto reload all the entries for keep watch on.

### Related issue(s)
Resolves #158 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->