### PR TITLE
Change port of local OAuth2 server to `58085`

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -88,7 +88,7 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 				ClientId:     "",
 				ClientSecret: "",
 			}
-      
+
 			configFile, err := config.DefaultLocalConfigPath()
 			errors.CheckError(err)
 			localConfig, err := config.ReadLocalConfig(configFile)
@@ -174,7 +174,7 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 	loginCmd.Flags().StringVar(&password, "password", "", "The password of an account to authenticate")
 	loginCmd.Flags().BoolVar(&sso, "sso", false, "Perform SSO login")
 	loginCmd.Flags().BoolVar(&ssoLaunchBrowser, "sso-launch-browser", true, "Automatically launch the system default browser when performing SSO login")
-	loginCmd.Flags().IntVar(&ssoProt, "sso-port", 8085, "Port to run local OAuth2 login application")
+	loginCmd.Flags().IntVar(&ssoProt, "sso-port", 58085, "Port to run local OAuth2 login application")
 
 	return loginCmd
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR changes port value of local OAuth callback server from `8085` to `58085`

### Related issue(s)
Fixes #169 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->