### PR TITLE
Feat: Adds implementation of `ClienOpts` in all remaining commads

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -55,5 +55,10 @@ func NewCommad() *cobra.Command {
 	command.PersistentFlags().BoolVar(&clientOpts.Verbose, "verbose", false, "Produce dumps of HTTP exchanges")
 	command.PersistentFlags().BoolVar(&clientOpts.InsecureTLS, "insecure-tls", false, "Whether to accept insecure HTTPS connection")
 	command.PersistentFlags().StringVar(&clientOpts.CaCertPaths, "caCerts", "", "Comma separated paths of CRT files to add to Root CAs")
+	command.PersistentFlags().StringVar(&clientOpts.ClientId, "keycloakClientId", "", "Keycloak Realm Service Account ClientId")
+	command.PersistentFlags().StringVar(&clientOpts.ClientSecret, "keycloakClientSecret", "", "Keycloak Realm Service Account ClientSecret")
+	command.PersistentFlags().StringVar(&clientOpts.ServerAddr, "microcksURL", "", "Microcks API URL")
+	command.MarkFlagsRequiredTogether("keycloakClientId", "microcksURL", "keycloakClientSecret")
+
 	return command
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -40,11 +40,11 @@ func NewCommad() *cobra.Command {
 
 	command.AddCommand(NewImportCommand(&clientOpts))
 	command.AddCommand(NewVersionCommand())
-	command.AddCommand(NewTestCommand())
-	command.AddCommand(NewImportURLCommand())
-	command.AddCommand(NewStartCommand())
-	command.AddCommand(NewStopCommand())
-	command.AddCommand(NewContextCommand())
+	command.AddCommand(NewTestCommand(&clientOpts))
+	command.AddCommand(NewImportURLCommand(&clientOpts))
+	command.AddCommand(NewStartCommand(&clientOpts))
+	command.AddCommand(NewStopCommand(&clientOpts))
+	command.AddCommand(NewContextCommand(&clientOpts))
 	command.AddCommand(NewLoginCommand(&clientOpts))
 	command.AddCommand(NewLogoutCommand(&clientOpts))
 

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -8,11 +8,12 @@ import (
 	"text/tabwriter"
 
 	"github.com/microcks/microcks-cli/pkg/config"
+	"github.com/microcks/microcks-cli/pkg/connectors"
 	"github.com/microcks/microcks-cli/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-func NewContextCommand() *cobra.Command {
+func NewContextCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 	var delete bool
 	ctxCmd := &cobra.Command{
 		Use:     "context [CONTEXT]",
@@ -27,24 +28,21 @@ microcks context httP://localhost:8080
 # Delete Microcks context
 microcks context httP://localhost:8080 --delete`,
 		Run: func(cmd *cobra.Command, args []string) {
-			var cfgFile string
-			configPath, err := config.DefaultLocalConfigPath()
-			errors.CheckError(err)
-			cfgFile = configPath
-			localCfg, err := config.ReadLocalConfig(cfgFile)
+			configPath := globalClientOpts.ConfigPath
+			localCfg, err := config.ReadLocalConfig(configPath)
 			errors.CheckError(err)
 			if delete {
 				if len(args) == 0 {
 					cmd.HelpFunc()(cmd, args)
 					os.Exit(1)
 				}
-				err := deleteContext(args[0], cfgFile)
+				err := deleteContext(args[0], configPath)
 				errors.CheckError(err)
 				return
 			}
 
 			if len(args) == 0 {
-				printMicrocksContexts(cfgFile)
+				printMicrocksContexts(configPath)
 				return
 			}
 

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -45,27 +45,56 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			config.CaCertPaths = globalClientOpts.CaCertPaths
 			config.Verbose = globalClientOpts.Verbose
 
-			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
-			if err != nil {
-				fmt.Println(err)
-				return
-			}
+			var mc connectors.MicrocksClient
 
-			if localConfig == nil {
-				fmt.Println("Please login to perform opertion...")
-				return
-			}
+			if globalClientOpts.ServerAddr != "" && globalClientOpts.ClientId != "" && globalClientOpts.ClientSecret != "" {
+				// create client with server address
+				mc = connectors.NewMicrocksClient(globalClientOpts.ServerAddr)
 
-			if globalClientOpts.Context == "" {
-				globalClientOpts.Context = localConfig.CurrentContext
-			}
+				keycloakURL, err := mc.GetKeycloakURL()
+				if err != nil {
+					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
+					os.Exit(1)
+				}
 
-			mc, err := connectors.NewClient(*globalClientOpts)
-			if err != nil {
-				fmt.Printf("error %v", err)
-				return
-			}
+				var oauthToken string = "unauthentifed-token"
+				if keycloakURL != "null" {
+					// If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
+					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret)
 
+					oauthToken, err = kc.ConnectAndGetToken()
+					if err != nil {
+						fmt.Printf("Got error when invoking Keycloack client: %s", err)
+						os.Exit(1)
+					}
+					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
+				}
+
+				//Set Auth token
+				mc.SetOAuthToken(oauthToken)
+			} else {
+
+				localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+
+				if localConfig == nil {
+					fmt.Println("Please login to perform opertion...")
+					return
+				}
+
+				if globalClientOpts.Context == "" {
+					globalClientOpts.Context = localConfig.CurrentContext
+				}
+
+				mc, err = connectors.NewClient(*globalClientOpts)
+				if err != nil {
+					fmt.Printf("error %v", err)
+					return
+				}
+			}
 			sepSpecificationFiles := strings.Split(specificationFiles, ",")
 			for _, f := range sepSpecificationFiles {
 				mainArtifact := true

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -27,15 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewImportURLCommand() *cobra.Command {
-	var (
-		microcksURL          string
-		keycloakClientID     string
-		keycloakClientSecret string
-		insecureTLS          bool
-		caCertPaths          string
-		verbose              bool
-	)
+func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 	var importURLCmd = &cobra.Command{
 		Use:   "import-url",
 		Short: "import API artifacts from URL on Microcks server",
@@ -49,40 +41,30 @@ func NewImportURLCommand() *cobra.Command {
 
 			specificationFiles := args[0]
 
-			// Collect optional HTTPS transport flags.
-			if insecureTLS {
-				config.InsecureTLS = true
-			}
-			if len(caCertPaths) > 0 {
-				config.CaCertPaths = caCertPaths
-			}
-			if verbose {
-				config.Verbose = true
-			}
+			config.InsecureTLS = globalClientOpts.InsecureTLS
+			config.CaCertPaths = globalClientOpts.CaCertPaths
+			config.Verbose = globalClientOpts.Verbose
 
-			// Now we seems to be good ...
-			// First - retrieve the Keycloak URL from Microcks configuration.
-			mc := connectors.NewMicrocksClient(microcksURL)
-			keycloakURL, err := mc.GetKeycloakURL()
+			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 			if err != nil {
-				fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
-				os.Exit(1)
+				fmt.Println(err)
+				return
 			}
 
-			var oauthToken string = "unauthentifed-token"
-			if keycloakURL != "null" {
-				//  If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
-				kc := connectors.NewKeycloakClient(keycloakURL, keycloakClientID, keycloakClientSecret)
-
-				oauthToken, err = kc.ConnectAndGetToken()
-				if err != nil {
-					fmt.Printf("Got error when invoking Keycloack client: %s", err)
-					os.Exit(1)
-				}
+			if localConfig == nil {
+				fmt.Println("Please login to perform opertion...")
+				return
 			}
 
-			// Then - for each specificationFile, upload the artifact on Microcks Server.
-			mc.SetOAuthToken(oauthToken)
+			if globalClientOpts.Context == "" {
+				globalClientOpts.Context = localConfig.CurrentContext
+			}
+
+			mc, err := connectors.NewClient(*globalClientOpts)
+			if err != nil {
+				fmt.Printf("error %v", err)
+				return
+			}
 
 			sepSpecificationFiles := strings.Split(specificationFiles, ",")
 			for _, f := range sepSpecificationFiles {
@@ -116,17 +98,6 @@ func NewImportURLCommand() *cobra.Command {
 			}
 		},
 	}
-	importURLCmd.Flags().StringVar(&microcksURL, "microcksURL", "", "Microcks API URL")
-	importURLCmd.Flags().StringVar(&keycloakClientID, "keycloakClientId", "", "Keycloak Realm Service Account ClientId")
-	importURLCmd.Flags().StringVar(&keycloakClientSecret, "keycloakClientSecret", "", "Keycloak Realm Service Account ClientSecret")
-	importURLCmd.Flags().BoolVar(&insecureTLS, "insecure", false, "Whether to accept insecure HTTPS connection")
-	importURLCmd.Flags().StringVar(&caCertPaths, "caCerts", "", "Comma separated paths of CRT files to add to Root CAs")
-	importURLCmd.Flags().BoolVar(&verbose, "verbose", false, "Produce dumps of HTTP exchanges")
-
-	//Marking flags 'required'
-	importURLCmd.MarkFlagRequired("microcksURL")
-	importURLCmd.MarkFlagRequired("keycloakClientId")
-	importURLCmd.MarkFlagRequired("keycloakClientSecret")
 
 	return importURLCmd
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewStartCommand() *cobra.Command {
+func NewStartCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 	var (
 		name       string
 		hostPort   string
@@ -34,8 +34,7 @@ microcks start --driver [driver you wnat either 'docker' or 'podman']
 microcks start --name [name of you container/instance]`,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			configFile, err := config.DefaultLocalConfigPath()
-			errors.CheckError(err)
+			configFile := globalClientOpts.ConfigPath
 			localConfig, err := config.ReadLocalConfig(configFile)
 			errors.CheckError(err)
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewStopCommand() *cobra.Command {
+func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 	var stopCmd = &cobra.Command{
 		Use:   "stop",
@@ -18,8 +18,7 @@ func NewStopCommand() *cobra.Command {
 		Long:  "stop microcks instance",
 		Run: func(cmd *cobra.Command, args []string) {
 
-			configFile, err := config.DefaultLocalConfigPath()
-			errors.CheckError(err)
+			configFile := globalClientOpts.ConfigPath
 			localConfig, err := config.ReadLocalConfig(configFile)
 			errors.CheckError(err)
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
+	"github.com/microcks/microcks-cli/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -31,19 +32,13 @@ var (
 	runnerChoices = map[string]bool{"HTTP": true, "SOAP_HTTP": true, "SOAP_UI": true, "POSTMAN": true, "OPEN_API_SCHEMA": true, "ASYNC_API_SCHEMA": true, "GRPC_PROTOBUF": true, "GRAPHQL_SCHEMA": true}
 )
 
-func NewTestCommand() *cobra.Command {
+func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 	var (
-		microcksURL          string
-		keycloakClientID     string
-		keycloakClientSecret string
-		waitFor              string
-		secretName           string
-		filteredOperations   string
-		operationsHeaders    string
-		oAuth2Context        string
-		insecureTLS          bool
-		caCertPaths          string
-		verbose              bool
+		waitFor            string
+		secretName         string
+		filteredOperations string
+		operationsHeaders  string
+		oAuth2Context      string
 	)
 	var testCmd = &cobra.Command{
 
@@ -85,15 +80,9 @@ func NewTestCommand() *cobra.Command {
 			}
 
 			// Collect optional HTTPS transport flags.
-			if insecureTLS {
-				config.InsecureTLS = true
-			}
-			if len(caCertPaths) > 0 {
-				config.CaCertPaths = caCertPaths
-			}
-			if verbose {
-				config.Verbose = true
-			}
+			config.InsecureTLS = globalClientOpts.InsecureTLS
+			config.CaCertPaths = globalClientOpts.CaCertPaths
+			config.Verbose = globalClientOpts.Verbose
 
 			// Compute time to wait in milliseconds.
 			var waitForMilliseconds int64 = 5000
@@ -107,30 +96,31 @@ func NewTestCommand() *cobra.Command {
 				waitForMilliseconds = waitForMilliseconds * 60 * 1000
 			}
 
-			// Now we seems to be good ...
-			// First - retrieve the Keycloak URL from Microcks configuration.
-			mc := connectors.NewMicrocksClient(microcksURL)
-			keycloakURL, err := mc.GetKeycloakURL()
+			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 			if err != nil {
-				fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
-				os.Exit(1)
+				fmt.Println(err)
+				return
 			}
 
-			var oauthToken string = "unauthentifed-token"
-			if keycloakURL != "null" {
-				// If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
-				kc := connectors.NewKeycloakClient(keycloakURL, keycloakClientID, keycloakClientSecret)
-
-				oauthToken, err = kc.ConnectAndGetToken()
-				if err != nil {
-					fmt.Printf("Got error when invoking Keycloack client: %s", err)
-					os.Exit(1)
-				}
-				//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
+			if localConfig == nil {
+				fmt.Println("Please login to perform opertion...")
+				return
 			}
 
-			// Then - launch the test on Microcks Server.
-			mc.SetOAuthToken(oauthToken)
+			if globalClientOpts.Context == "" {
+				globalClientOpts.Context = localConfig.CurrentContext
+			}
+
+			mc, err := connectors.NewClient(*globalClientOpts)
+			if err != nil {
+				fmt.Printf("error %v", err)
+				return
+			}
+
+			ctx, err := localConfig.ResolveContext(globalClientOpts.Context)
+			errors.CheckError(err)
+
+			serverAddr := ctx.Server.Server
 
 			var testResultID string
 			testResultID, err = mc.CreateTestResult(serviceRef, testEndpoint, runnerType, secretName, waitForMilliseconds, filteredOperations, operationsHeaders, oAuth2Context)
@@ -166,7 +156,7 @@ func NewTestCommand() *cobra.Command {
 				time.Sleep(2 * time.Second)
 			}
 
-			fmt.Printf("Full TestResult details are available here: %s/#/tests/%s \n", strings.Split(microcksURL, "/api")[0], testResultID)
+			fmt.Printf("Full TestResult details are available here: %s/#/tests/%s \n", serverAddr, testResultID)
 
 			if !success {
 				os.Exit(1)
@@ -174,22 +164,11 @@ func NewTestCommand() *cobra.Command {
 		},
 	}
 
-	testCmd.Flags().StringVar(&microcksURL, "microcksURL", "", "Microcks API URL")
-	testCmd.Flags().StringVar(&keycloakClientID, "keycloakClientId", "", "Keycloak Realm Service Account ClientId")
-	testCmd.Flags().StringVar(&keycloakClientSecret, "keycloakClientSecret", "", "Keycloak Realm Service Account ClientSecret")
 	testCmd.Flags().StringVar(&waitFor, "waitFor", "5sec", "Time to wait for test to finish")
 	testCmd.Flags().StringVar(&secretName, "secretName", "", "Secret to use for connecting test endpoint")
 	testCmd.Flags().StringVar(&filteredOperations, "filteredOperations", "", "List of operations to launch a test for")
 	testCmd.Flags().StringVar(&operationsHeaders, "operationsHeaders", "", "Override of operations headers as JSON string")
 	testCmd.Flags().StringVar(&oAuth2Context, "oAuth2Context", "", "Spec of an OAuth2 client context as JSON string")
-	testCmd.Flags().BoolVar(&insecureTLS, "insecure", false, "Whether to accept insecure HTTPS connection")
-	testCmd.Flags().StringVar(&caCertPaths, "caCerts", "", "Comma separated paths of CRT files to add to Root CAs")
-	testCmd.Flags().BoolVar(&verbose, "verbose", false, "Produce dumps of HTTP exchanges")
-
-	//Marking flags 'required'
-	testCmd.MarkFlagRequired("microcksURL")
-	testCmd.MarkFlagRequired("keycloakClientId")
-	testCmd.MarkFlagRequired("keycloakClientSecret")
 
 	return testCmd
 }

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -87,13 +87,15 @@ type OAuth2ClientContext struct {
 }
 
 type ClientOptions struct {
-	ServerAddr  string
-	Context     string
-	ConfigPath  string
-	AuthToken   string
-	InsecureTLS bool
-	Verbose     bool
-	CaCertPaths string
+	ServerAddr   string
+	Context      string
+	ConfigPath   string
+	AuthToken    string
+	InsecureTLS  bool
+	Verbose      bool
+	CaCertPaths  string
+	ClientId     string
+	ClientSecret string
 }
 
 type microcksClient struct {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR adds the implementation of `GlobalClientOpt` in all commands.
- It allows initiating the microcks client with some specific configuration to talk with microcks instance.
- It allows users to use different config file, different context to perform a specific operation.

### Related issue(s)
Fixes #160 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->