### PR TITLE
Fix: MicrocksClient with GlobalClientOptions is not able to handle insucure TLS request

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -67,6 +67,10 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 				os.Exit(1)
 			}
 
+			config.InsecureTLS = globalClientOpts.InsecureTLS
+			config.CaCertPaths = globalClientOpts.CaCertPaths
+			config.Verbose = globalClientOpts.Verbose
+
 			server = args[0]
 			mc := connectors.NewMicrocksClient(server)
 			keycloakUrl, err := mc.GetKeycloakURL()

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -149,7 +149,16 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 		c.Verbose = opts.Verbose
 	}
 
-	c.httpClient = &http.Client{}
+	if config.InsecureTLS || len(config.CaCertPaths) > 0 {
+		tlsConfig := config.CreateTLSConfig()
+		tr := &http.Transport{
+			TLSClientConfig: tlsConfig,
+		}
+		c.httpClient = &http.Client{Transport: tr}
+	} else {
+		c.httpClient = http.DefaultClient
+	}
+
 	if localCfg != nil {
 		err = c.refreshAuthToken(localCfg, ctxName, opts.ConfigPath)
 		if err != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR fixes MicrocksClient, which was not able to handle insecure TLS request previously.


### Related issue(s)
Fixes #180 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->