### PR TITLE
Update Go base image to version 1.24.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build binary
-FROM --platform=$BUILDPLATFORM golang:1.23.0-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.24.0-alpine AS build-env
 ADD . /app
 WORKDIR /app
 ARG TARGETOS


### PR DESCRIPTION
Updating Golang base image to 1.24.0 as our mod file is using go 1.24.0 as per #207

### Description

- Updating Golang base image to 1.24.0 as our mod file is using go 1.24.0 as per #207
### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->