### PR TITLE
Update Go and base image versions in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build binary
-FROM --platform=$BUILDPLATFORM golang:1.24.10-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.25.9-alpine AS build-env
 ADD . /app
 WORKDIR /app
 ARG TARGETOS
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags="-s -w" -o microcks github.com/microcks/microcks-cli
     
 # Build image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1763362218
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
 
 # Some version information
 LABEL maintainer="Laurent Broudoux <laurent@microcks.io>" \


### PR DESCRIPTION
This is fixing the next release of the container image, otherwise you will get this error while the `docker build` will be executed in https://github.com/microcks/microcks-cli/blob/master/.github/workflows/build-verify.yml#L86:
```none
 => ERROR [build-env 4/4] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build -ldflags="-s -w" -o microcks github.com/microcks/microcks-cli                                                                                                             0.3s
------                                                                                                                                                                                                                                                          
 > [build-env 4/4] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build -ldflags="-s -w" -o microcks github.com/microcks/microcks-cli:
0.273 go: go.mod requires go >= 1.25.0 (running go 1.24.10; GOTOOLCHAIN=local)
------
Dockerfile:7
--------------------
   6 |     ARG TARGETARCH
   7 | >>> RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
   8 | >>>     go build -ldflags="-s -w" -o microcks github.com/microcks/microcks-cli
   9 |         
--------------------
```

So bumping the `Dockerfile` to same 1.25 (Minor version) as the `go.mod` file: https://github.com/microcks/microcks-cli/blob/master/go.mod#L3.

Not related to fixing the `docker build` error, but these bumps to current latest below will also fix a lot of CVEs:
- `golang:1.24.0` --> `golang:1.25.9`
- `ubi-minimal:9.7-1763362218` --> `ubi-minimal:9.7-1776833838`

_Note: As part of this PR, the `go.mod` file is not updated to `1.25.9` (keeping `1.25.0`) as it's not mandatory. This could be done in another PR per se._

Locally I built and ran this command: `docker scout compare --ignore-unchanged --to microcks/microcks-cli:1.0.2 local://microcks-cli:after`, showing the differences and improvements:
<img width="2182" height="708" alt="image" src="https://github.com/user-attachments/assets/15a603ee-33fc-472c-8d66-dad2eba58efb" />

Also, as a smoke tests, I successfully ran these commands:
```bash
docker run --rm -it microcks-cli:after microcks help
docker run --rm -it microcks-cli:after microcks version
```
