### PR TITLE
chore: replace deprecated io/ioutil with io and os packages

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -54,7 +53,7 @@ func CreateTLSConfig() *tls.Config {
 		sepCaFiles := strings.Split(CaCertPaths, ",")
 		for _, f := range sepCaFiles {
 			// Read in the cert file
-			certs, err := ioutil.ReadFile(f)
+			certs, err := os.ReadFile(f)
 			if err != nil {
 				fmt.Println("Unable to read cert file from CaCertPaths: " + f)
 			}

--- a/pkg/connectors/keycloak_client.go
+++ b/pkg/connectors/keycloak_client.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -95,7 +95,7 @@ func (c *keycloakClient) ConnectAndGetToken() (string, error) {
 	// Dump response if verbose required.
 	config.DumpResponseIfRequired("Keycloak for getting token", resp, true)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -125,7 +125,7 @@ func (c *keycloakClient) GetOIDCConfig() (*oauth2.Config, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -172,7 +172,7 @@ func (c *keycloakClient) ConnectAndGetTokenAndRefreshToken(username, password st
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -23,7 +23,6 @@ import (
 	errs "errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -227,7 +226,7 @@ func (c *microcksClient) GetKeycloakURL() (string, error) {
 	// Dump request if verbose required.
 	config.DumpResponseIfRequired("Microcks for getting Keycloak config", resp, true)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -366,7 +365,7 @@ func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string,
 	// Dump response if verbose required.
 	config.DumpResponseIfRequired("Microcks for creating test", resp, true)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -405,7 +404,7 @@ func (c *microcksClient) GetTestResult(testResultID string) (*TestResultSummary,
 	// Dump response if verbose required.
 	config.DumpResponseIfRequired("Microcks for getting status test", resp, true)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
`io/ioutil` was soft deprecated in go 1.16. the replacements have been available since go 1.16 and are now the standard:

- `ioutil.ReadAll` -> `io.ReadAll`
- `ioutil.ReadFile` -> `os.ReadFile`

files changed:
- `pkg/connectors/microcks_client.go` - 3 call sites (`GetKeycloakURL`, `CreateTestResult`, `GetTestResult`)
- `pkg/connectors/keycloak_client.go` - 3 call sites (`ConnectAndGetToken`, `GetOIDCConfig`, `ConnectAndGetTokenAndRefreshToken`)
- `pkg/config/config.go` - 1 call site (`CreateTLSConfig`)

no behavior change. `microcks_client.go` already imported `io` and used `io.ReadAll` in `UploadArtifact` and `DownloadArtifact`, so this just makes the rest of the file consistent.