### PR TITLE
fix: handle json.Unmarshal error in GetTestResult

### DIFF
--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -410,9 +410,11 @@ func (c *microcksClient) GetTestResult(testResultID string) (*TestResultSummary,
 	}
 
 	result := TestResultSummary{}
-	json.Unmarshal([]byte(body), &result)
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse test result response: %w", err)
+	}
 
-	return &result, err
+	return &result, nil
 }
 
 func (c *microcksClient) UploadArtifact(specificationFilePath string, mainArtifact bool) (string, error) {


### PR DESCRIPTION
`GetTestResult` in `microcks_client.go` called `json.Unmarshal` but ignored the returned error. every other unmarshal call in the same file checks it, this one didn't.

the problem is that if the api returns something unexpected (an html error page, a rate-limit response, or a not-yet-ready response during startup), `json.Unmarshal` fails silently and `result` stays as a zero-value `TestResultSummary` with `Success=false` and `InProgress=false`. the polling loop in `cmd/test.go` sees `inProgress=false`, exits immediately, and the user gets a failure with no useful message.

the fix is straightforward: check the error and return it so the caller gets a real error instead of a silent bad result.

also removed the redundant `[]byte(body)` cast since `io.ReadAll` already returns `[]byte`.