### PR TITLE
fix: read response body in DownloadArtifact

### DIFF
--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -520,7 +520,7 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 	// Dump response if verbose required.
 	config.DumpResponseIfRequired("Microcks for uploading artifact", resp, true)
 
-	respBody, err := io.ReadAll(req.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/pkg/connectors/microcks_client_test.go
+++ b/pkg/connectors/microcks_client_test.go
@@ -1,0 +1,43 @@
+package connectors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDownloadArtifactReturnsResponseBody(t *testing.T) {
+	const expectedBody = "artifact downloaded"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/artifact/download" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if err := r.ParseMultipartForm(1024); err != nil {
+			t.Fatalf("failed to parse multipart form: %v", err)
+		}
+		if got := r.FormValue("url"); got != "https://example.com/openapi.yaml" {
+			t.Fatalf("unexpected artifact url: %s", got)
+		}
+		if got := r.FormValue("mainArtifact"); got != "true" {
+			t.Fatalf("unexpected mainArtifact value: %s", got)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(expectedBody))
+	}))
+	defer server.Close()
+
+	client := NewMicrocksClient(server.URL)
+
+	msg, err := client.DownloadArtifact("https://example.com/openapi.yaml", true, "")
+	if err != nil {
+		t.Fatalf("DownloadArtifact returned error: %v", err)
+	}
+	if strings.TrimSpace(msg) != expectedBody {
+		t.Fatalf("expected response body %q, got %q", expectedBody, msg)
+	}
+}


### PR DESCRIPTION
DownloadArtifact was reading from req.Body after the request completed instead of reading resp.Body. That means the CLI returned the multipart request payload, or an empty body, instead of the Microcks API response/error message from /artifact/download.

This PR changes DownloadArtifact to read resp.Body and adds an httptest coverage case that verifies the returned message comes from the server response.

Verification:
- go test ./pkg/connectors

Note: go test ./... still fails on the existing cmd/context_test.go setup because ./testdata/local.config cannot be created when cmd/testdata is absent. That failure is unrelated to this change.