### PR TITLE
Add `go vet` to Makefile and fix silent error in executor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ WATCHER_NAME=watcher
 HOST_OS=$(shell go env GOOS)
 HOST_ARCH=$(shell go env GOARCH)
 
+.PHONY: vet
+vet:
+	go vet ./...
+
 .PHONY: build-local
 build-local:
 	go build -o ${DIST_DIR}/${BIN_NAME}

--- a/pkg/watcher/executor.go
+++ b/pkg/watcher/executor.go
@@ -12,7 +12,7 @@ func TriggerImport(entry config.WatchEntry) {
 	// Retrieve config to get client options.
 	cfgPath, err := config.DefaultLocalConfigPath()
 	if err != nil {
-		fmt.Errorf("Error while loading config: %s", err.Error())
+		fmt.Printf("Error while loading config: %s\n", err.Error())
 	}
 
 	fmt.Println("[INFO] Re-importing changed file: " + entry.FilePath)


### PR DESCRIPTION
- The change adds an option to run `go vet`, the static analyzer.
- Fixes the silent error in executor.go