### PR TITLE
fix: exit with clear error when --waitFor value is not a valid number

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -76,7 +76,8 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 			// Validate presence and values of flags.
 			if !strings.HasSuffix(waitFor, "milli") && !strings.HasSuffix(waitFor, "sec") && !strings.HasSuffix(waitFor, "min") {
-				fmt.Println("--waitFor format is wrong. Applying default 5sec")
+				fmt.Println("--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)")
+				os.Exit(1)
 			}
 
 			// Collect optional HTTPS transport flags.
@@ -85,15 +86,28 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			config.Verbose = globalClientOpts.Verbose
 
 			// Compute time to wait in milliseconds.
-			var waitForMilliseconds int64 = 5000
+			var waitForMilliseconds int64
 			if strings.HasSuffix(waitFor, "milli") {
-				waitForMilliseconds, _ = strconv.ParseInt(waitFor[:len(waitFor)-5], 0, 64)
+				n, err := strconv.ParseInt(waitFor[:len(waitFor)-5], 0, 64)
+				if err != nil {
+					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
+					os.Exit(1)
+				}
+				waitForMilliseconds = n
 			} else if strings.HasSuffix(waitFor, "sec") {
-				waitForMilliseconds, _ = strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
-				waitForMilliseconds = waitForMilliseconds * 1000
+				n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
+				if err != nil {
+					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
+					os.Exit(1)
+				}
+				waitForMilliseconds = n * 1000
 			} else if strings.HasSuffix(waitFor, "min") {
-				waitForMilliseconds, _ = strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
-				waitForMilliseconds = waitForMilliseconds * 60 * 1000
+				n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
+				if err != nil {
+					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
+					os.Exit(1)
+				}
+				waitForMilliseconds = n * 60 * 1000
 			}
 
 			var mc connectors.MicrocksClient


### PR DESCRIPTION
passing an invalid number to `--waitFor` (e.g. `--waitFor abcsec`) would silently set the timeout to 0ms. the suffix check passed because the unit was correct, but `strconv.ParseInt` returned 0 on the unparseable prefix and the error was discarded with `_`. the test then fired with a zero timeout and always failed, with no indication of what went wrong.

this also affects the invalid-suffix path: the old code printed a warning but did not exit, so the command continued with whatever value `waitForMilliseconds` happened to have.

both cases now exit with a clear message pointing at the bad value.

tested manually:
```
$ microcks test ... --waitFor abcsec
--waitFor value "abcsec" is not a valid number

$ microcks test ... --waitFor 30s
--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)
```