### PR TITLE
fix: avoid nil interface panic on Keycloak config discovery

### DIFF
--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -238,11 +238,11 @@ func (c *microcksClient) GetKeycloakURL() (string, error) {
 
 	// Retrieve auth server url and realm name.
 	enabled := configResp["enabled"].(bool)
-	authServerURL := configResp["auth-server-url"].(string)
-	realmName := configResp["realm"].(string)
 
 	// Return a proper URL or 'null' if Keycloak is disables.
 	if enabled {
+		authServerURL := configResp["auth-server-url"].(string)
+		realmName := configResp["realm"].(string)
 		return authServerURL + "/realms/" + realmName + "/", nil
 	}
 	return "null", nil

--- a/pkg/connectors/microcks_client_test.go
+++ b/pkg/connectors/microcks_client_test.go
@@ -1,0 +1,62 @@
+package connectors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetKeycloakURL_Disabled(t *testing.T) {
+	// Create a mock server that returns keycloak disabled response
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/keycloak/config" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"enabled": false}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	// Initialize the MicrocksClient with the mock server URL
+	client := NewMicrocksClient(ts.URL)
+
+	// Call GetKeycloakURL and check for panic/error
+	url, err := client.GetKeycloakURL()
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if url != "null" {
+		t.Errorf("Expected 'null', got '%s'", url)
+	}
+}
+
+func TestGetKeycloakURL_Enabled(t *testing.T) {
+	// Create a mock server that returns keycloak enabled response
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/keycloak/config" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"enabled": true, "auth-server-url": "http://keycloak:8080/auth", "realm": "microcks"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	// Initialize the MicrocksClient with the mock server URL
+	client := NewMicrocksClient(ts.URL)
+
+	// Call GetKeycloakURL and check for panic/error
+	url, err := client.GetKeycloakURL()
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	expected := "http://keycloak:8080/auth/realms/microcks/"
+	if url != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, url)
+	}
+}


### PR DESCRIPTION
### Description

- Fixes a critical runtime panic in `GetKeycloakURL()` when interacting with a Microcks server that has Keycloak disabled.
- Previously, the CLI performed unconditional type assertions on `auth-server-url` and `realm` fields, which are absent when the `/api/keycloak/config` endpoint returns `{ "enabled": false }`. This caused a fatal panic:  
  `panic: interface conversion: interface {} is nil, not string`.
- Updated logic to first check the `enabled` flag and only access Keycloak-specific fields when it is `true`.
- Ensures the CLI returns `"null"` safely when Keycloak is disabled instead of crashing.

#### Implementation Details

```go
enabled := configResp["enabled"].(bool)

if enabled {
    authServerURL := configResp["auth-server-url"].(string)
    realmName := configResp["realm"].(string)
    return authServerURL + "/realms/" + realmName + "/", nil
}
return "null", nil
```

### Testing & Prevention

- Added unit tests in `pkg/connectors/microcks_client_test.go` using `httptest.Server`.
- Covered both scenarios:
  - Keycloak enabled → validates correct URL construction.
  - Keycloak disabled → verifies no panic and correct `"null"` return.
- All tests pass successfully.

### Impact

- Prevents fatal runtime crashes during CLI operations such as:
  - `microcks login`
  - `microcks test`
  - Token refresh flows
- Enables seamless usage of the CLI with Microcks deployments where Keycloak is intentionally disabled (common in local setups and CI/CD pipelines).
- Eliminates a class of interface conversion panics caused by unsafe type assertions on missing JSON fields.
- Improves overall CLI robustness and production reliability.

---

### Related issue(s)

Fixes #267 