### PR TITLE
Inject version commit and build tag metadata with Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,13 @@ WATCHER_NAME=watcher
 
 HOST_OS=$(shell go env GOOS)
 HOST_ARCH=$(shell go env GOARCH)
+VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || echo unknown)
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+LDFLAGS=-X ${PACKAGE}/version.Version=${VERSION} -X ${PACKAGE}/version.Commit=${COMMIT}
 
 .PHONY: build-local
 build-local:
-	go build -o ${DIST_DIR}/${BIN_NAME}
+	go build -ldflags "${LDFLAGS}" -o ${DIST_DIR}/${BIN_NAME}
 
 .PHONY: clean
 clean:
@@ -24,6 +27,12 @@ build-binaries:
 	make BIN_NAME=${CLI_NAME}-darwin-arm64 GOOS=darwin GOARCH=arm64 build-local
 	make BIN_NAME=${CLI_NAME}-windows-amd64.exe GOOS=windows build-local
 	make BIN_NAME=${CLI_NAME}-windows-386.exe GOOS=windows GOARCH=386 build-local
+
+.PHONY: build-release
+build-release:
+	$(eval RELEASE_VERSION := $(shell git describe --tags --exact-match 2>/dev/null))
+	@test -n "${RELEASE_VERSION}" || (echo "build-release must be run from a git tag" && exit 1)
+	make VERSION=${RELEASE_VERSION} build-binaries
 
 .PHONY: build-watcher
 build-watcher:

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,15 @@ WATCHER_NAME=watcher
 
 HOST_OS=$(shell go env GOOS)
 HOST_ARCH=$(shell go env GOARCH)
+GO ?= go
+BUILD_FLAGS ?=
 VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || echo unknown)
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 LDFLAGS=-X ${PACKAGE}/version.Version=${VERSION} -X ${PACKAGE}/version.Commit=${COMMIT}
 
 .PHONY: build-local
 build-local:
-	go build -ldflags "${LDFLAGS}" -o ${DIST_DIR}/${BIN_NAME}
+	$(GO) build $(BUILD_FLAGS) -ldflags "${LDFLAGS}" -o ${DIST_DIR}/${BIN_NAME}
 
 .PHONY: clean
 clean:
@@ -36,4 +38,4 @@ build-release:
 
 .PHONY: build-watcher
 build-watcher:
-	go build -o ${DIST_DIR}/${BIN_NAME}-${WATCHER_NAME} ${PACKAGE}/watcher
+	$(GO) build $(BUILD_FLAGS) -o ${DIST_DIR}/${BIN_NAME}-${WATCHER_NAME} ${PACKAGE}/watcher

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
 	"github.com/microcks/microcks-cli/pkg/errors"
+	"github.com/microcks/microcks-cli/version"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +30,7 @@ func NewCommad() *cobra.Command {
 	command := &cobra.Command{
 		Use:          "microcks",
 		Short:        "A CLI tool for Microcks",
+		Version:      version.Info(),
 		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
@@ -37,6 +39,7 @@ func NewCommad() *cobra.Command {
 			HiddenDefaultCmd: true,
 		},
 	}
+	command.SetVersionTemplate("{{.Version}}\n")
 
 	command.AddCommand(NewImportCommand(&clientOpts))
 	command.AddCommand(NewImportDirCommand(&clientOpts))

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,10 +25,10 @@ import (
 func NewVersionCommand() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number of microkcs CLI",
-		Long:  `Print the version number of microkcs CLI`,
+		Short: "Print the version number of Microcks CLI",
+		Long:  `Print the version number of Microcks CLI`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Microcks-CLI %s\n", version.Version)
+			fmt.Println(version.Info())
 		},
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,10 @@
 package version
 
 var (
-	Version = "1.0.3"
+	Version = "unknown"
+	Commit  = "unknown"
 )
+
+func Info() string {
+	return "Microcks CLI " + Version + "\nCommit: " + Commit
+}


### PR DESCRIPTION
### Description

This PR uses the existing Makefile build flow to inject version and commit metadata at build time.

For local/source builds, the version is derived from `git describe --tags --dirty --always`, so unreleased binaries include the nearest tag, commit distance, commit hash, and dirty state when applicable:

```text
Microcks CLI 1.0.2-43-g1dad150-dirty
Commit: 1dad150
```

In a tagged release, `make build-release` uses the exact git tag as the version.

This also wires Cobra's standard `--version` flag to the same output as `microcks version`.

The Makefile now keeps `VERSION` and `COMMIT` overridable and also allows custom `GO` / `BUILD_FLAGS` parameters, which makes source packaging and downstream build wrappers easier without changing the target logic.

### Related issue(s)

Fixes #275