### PR TITLE
fix: validate start command port flag

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
@@ -33,6 +34,8 @@ microcks start --driver [driver you wnat either 'docker' or 'podman']
 # Define name of your microcks container/instance
 microcks start --name [name of you container/instance]`,
 		Run: func(cmd *cobra.Command, args []string) {
+			err := validateStartPort(hostPort)
+			errors.CheckError(err)
 
 			configFile := globalClientOpts.ConfigPath
 			localConfig, err := config.ReadLocalConfig(configFile)
@@ -149,4 +152,12 @@ microcks start --name [name of you container/instance]`,
 	startCmd.Flags().BoolVar(&autoRemove, "rm", false, "mimic of '--rm' flag of dokcer to automatically remove the container when it exits")
 	startCmd.Flags().StringVar(&driver, "driver", "docker", "use --driver to change driver from docker to podman")
 	return startCmd
+}
+
+func validateStartPort(port string) error {
+	portNum, err := strconv.Atoi(port)
+	if err != nil || portNum < 1 || portNum > 65535 {
+		return fmt.Errorf("--port must be a number between 1 and 65535, got %q", port)
+	}
+	return nil
 }

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateStartPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		port    string
+		wantErr bool
+	}{
+		{name: "lowest valid port", port: "1"},
+		{name: "default port", port: "8585"},
+		{name: "highest valid port", port: "65535"},
+		{name: "non numeric port", port: "abc", wantErr: true},
+		{name: "zero port", port: "0", wantErr: true},
+		{name: "negative port", port: "-1", wantErr: true},
+		{name: "port above range", port: "65536", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateStartPort(tt.port)
+			if tt.wantErr {
+				require.EqualError(t, err, "--port must be a number between 1 and 65535, got "+strconv.Quote(tt.port))
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
microcks start now validates --port before it reads config or calls the container driver. Invalid values such as abc, 0, negative numbers, and values above 65535 return a clear command error instead of being passed into Docker or Podman.

Added unit coverage for valid boundary ports and invalid inputs. Tested with go test ./... and make build-binaries.

example output with an invalid port: 
<img width="638" height="86" alt="image" src="https://github.com/user-attachments/assets/4f6cf413-fe30-47a3-8843-77962d4a13ad" />