### PR TITLE
fix(typo): microkcs CLI instead of microkcs CLI

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -78,7 +78,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloack client: %s", err)
+						fmt.Printf("Got error when invoking Keycloak client: %s", err)
 						os.Exit(1)
 					}
 					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -57,14 +57,14 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 					os.Exit(1)
 				}
 
-				var oauthToken string = "unauthentifed-token"
+				var oauthToken string = "unauthenticated-token"
 				if keycloakURL != "null" {
 					// If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
 					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret)
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloack client: %s", err)
+						fmt.Printf("Got error when invoking Keycloak client: %s", err)
 						os.Exit(1)
 					}
 					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
@@ -81,7 +81,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 				}
 
 				if localConfig == nil {
-					fmt.Println("Please login to perform opertion...")
+					fmt.Println("Please login to perform operation...")
 					return
 				}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -61,7 +61,7 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 			ctx := cmd.Context()
 			var server string
 
-			//Checkc if server name is provided or not
+			//Check if server name is provided or not
 			if len(args) != 1 {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -42,7 +42,7 @@ func NewLoginCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command 
 		Long:  "Login into Microcks instance",
 		Example: `microcks login http://locahost:8080
 
-# Provide name to your logged in context (Defautl context name is server name)
+# Provide name to your logged in context (Default context name is server name)
 microcks login http://localhost:8080 --name
 
 # Provide username and password as flags
@@ -61,7 +61,7 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 			ctx := cmd.Context()
 			var server string
 
-			//Chekc if server name is provided or not
+			//Checkc if server name is provided or not
 			if len(args) != 1 {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
@@ -104,14 +104,14 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 
 			if keycloakUrl == "null" {
 				localConfig.UpsertServer(config.Server{
-					Server:          server,
-					InsecureTLS:     true,
-					KeycloackEnable: false,
+					Server:         server,
+					InsecureTLS:    true,
+					KeycloakEnable: false,
 				})
 				fmt.Print("No login required...\n")
 			} else {
 				if !sso {
-					//Chek for the enviroment variables
+					//Check for the enviroment variables
 					clientID := os.Getenv("MICROCKS_CLIENT_ID")
 					clientSecret := os.Getenv("MICROCKS_CLIENT_SECRET")
 
@@ -145,13 +145,13 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 				fmt.Printf("'%s' logged in successfully\n", em)
 
 				localConfig.UpsertServer(config.Server{
-					Server:          server,
-					InsecureTLS:     true,
-					KeycloackEnable: true,
+					Server:         server,
+					InsecureTLS:    true,
+					KeycloakEnable: true,
 				})
 			}
 
-			localConfig.UpserAuth(authCfg)
+			localConfig.UpsertAuth(authCfg)
 
 			localConfig.UpsertUser(config.User{
 				Name:         server,

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -110,13 +110,13 @@ microcks start --name [name of you container/instance]`,
 			server := fmt.Sprintf("http://localhost:%s", instance.Port)
 
 			localConfig.UpsertServer(config.Server{
-				Name:            name,
-				Server:          server,
-				InsecureTLS:     true,
-				KeycloackEnable: false,
+				Name:           name,
+				Server:         server,
+				InsecureTLS:    true,
+				KeycloakEnable: false,
 			})
 
-			localConfig.UpserAuth(config.Auth{
+			localConfig.UpsertAuth(config.Auth{
 				Server:       server,
 				ClientId:     "",
 				ClientSecret: "",

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -125,14 +125,14 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 					os.Exit(1)
 				}
 
-				var oauthToken string = "unauthentifed-token"
+				var oauthToken string = "unauthenticated-token"
 				if keycloakURL != "null" {
 					// If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
 					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret)
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloack client: %s", err)
+						fmt.Printf("Got error when invoking Keycloak client: %s", err)
 						os.Exit(1)
 					}
 					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
@@ -149,7 +149,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				}
 
 				if localConfig == nil {
-					fmt.Println("Please login to perform opertion...")
+					fmt.Println("Please login to perform operation...")
 					return
 				}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,8 +25,8 @@ import (
 func NewVersionCommand() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number of microkcs CLI",
-		Long:  `Print the version number of microkcs CLI`,
+		Short: "Print the version number of microcks CLI",
+		Long:  `Print the version number of microcks CLI`,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Microcks-CLI %s\n", version.Version)
 		},

--- a/documentation/cmd/login.md
+++ b/documentation/cmd/login.md
@@ -6,7 +6,7 @@ Log in to a Microcks instance using username/password or SSO. Creates or updates
 # Login to microcks using a username and password
 microcks login http://locahost:8080
 
-# Provide name to your logged in context (Defautl context name is server name)
+# Provide name to your logged in context (Default context name is server name)
 microcks login http://localhost:8080 --name
 
 # Provide username and password as flags

--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -39,10 +39,10 @@ type User struct {
 }
 
 type Server struct {
-	Name            string `yaml:"name"`
-	Server          string `yaml:"server"`
-	InsecureTLS     bool   `yaml:"insecureTLS"`
-	KeycloackEnable bool   `yaml:"keycloakEnable"`
+	Name           string `yaml:"name"`
+	Server         string `yaml:"server"`
+	InsecureTLS    bool   `yaml:"insecureTLS"`
+	KeycloakEnable bool   `yaml:"keycloakEnable"`
 }
 
 type Instance struct {
@@ -348,7 +348,7 @@ func (l *LocalConfig) GetAuth(server string) (*Auth, error) {
 	return nil, fmt.Errorf("Auth for '%s' is undifined", server)
 }
 
-func (l *LocalConfig) UpserAuth(auth Auth) {
+func (l *LocalConfig) UpsertAuth(auth Auth) {
 	for i, a := range l.Auths {
 		if a.Server == auth.Server {
 			l.Auths[i] = auth

--- a/pkg/connectors/keycloak_client.go
+++ b/pkg/connectors/keycloak_client.go
@@ -183,7 +183,7 @@ func (c *keycloakClient) ConnectAndGetTokenAndRefreshToken(username, password st
 	}
 
 	authToken := openIDResp["access_token"].(string)
-	refershToken := openIDResp["refresh_token"].(string)
+	refreshToken := openIDResp["refresh_token"].(string)
 
-	return authToken, refershToken, nil
+	return authToken, refreshToken, nil
 }

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -124,7 +124,7 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 			return nil, err
 		}
 		c.ServerAddr = configCtx.Server.Server
-		c.Insecure = configCtx.Server.KeycloackEnable
+		c.Insecure = configCtx.Server.KeycloakEnable
 		c.InsecureTLS = configCtx.Server.InsecureTLS
 		c.AuthToken = configCtx.User.AuthToken
 		c.RefreshToken = configCtx.User.RefreshToken
@@ -338,7 +338,7 @@ func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string,
 	if len(operationsHeaders) > 0 && ensureValidOperationsHeaders(operationsHeaders) {
 		input += (", \"operationsHeaders\": " + operationsHeaders)
 	}
-	if len(oAuth2Context) > 0 && ensureValieOAuth2Context(oAuth2Context) {
+	if len(oAuth2Context) > 0 && ensureValidOAuth2Context(oAuth2Context) {
 		input += (", \"oAuth2Context\": " + oAuth2Context)
 	}
 
@@ -557,7 +557,7 @@ func ensureValidOperationsHeaders(operationsHeaders string) bool {
 	return true
 }
 
-func ensureValieOAuth2Context(oAuth2Context string) bool {
+func ensureValidOAuth2Context(oAuth2Context string) bool {
 	var oContext = OAuth2ClientContext{}
 	err := json.Unmarshal([]byte(oAuth2Context), &oContext)
 	if err != nil {


### PR DESCRIPTION
### Related issue : #282 
There was a small typo in available commands, which is fixed by this pr

<img width="1463" height="313" alt="Screenshot (680)" src="https://github.com/user-attachments/assets/66834f71-0189-4803-bbf1-decd4a45615b" />
