### PR TITLE
fix: code quality improvements  vet target, bug fixes, and typo corrections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ build-binaries:
 .PHONY: build-watcher
 build-watcher:
 	go build -o ${DIST_DIR}/${BIN_NAME}-${WATCHER_NAME} ${PACKAGE}/watcher
+
+.PHONY: vet
+vet:
+	go vet ./...

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -339,7 +339,7 @@ func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string,
 	if len(operationsHeaders) > 0 && ensureValidOperationsHeaders(operationsHeaders) {
 		input += (", \"operationsHeaders\": " + operationsHeaders)
 	}
-	if len(oAuth2Context) > 0 && ensureValieOAuth2Context(oAuth2Context) {
+	if len(oAuth2Context) > 0 && ensureValidOAuth2Context(oAuth2Context) {
 		input += (", \"oAuth2Context\": " + oAuth2Context)
 	}
 
@@ -521,7 +521,7 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 	// Dump response if verbose required.
 	config.DumpResponseIfRequired("Microcks for uploading artifact", resp, true)
 
-	respBody, err := io.ReadAll(req.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -556,7 +556,7 @@ func ensureValidOperationsHeaders(operationsHeaders string) bool {
 	return true
 }
 
-func ensureValieOAuth2Context(oAuth2Context string) bool {
+func ensureValidOAuth2Context(oAuth2Context string) bool {
 	var oContext = OAuth2ClientContext{}
 	err := json.Unmarshal([]byte(oAuth2Context), &oContext)
 	if err != nil {

--- a/pkg/watcher/executor.go
+++ b/pkg/watcher/executor.go
@@ -12,7 +12,7 @@ func TriggerImport(entry config.WatchEntry) {
 	// Retrieve config to get client options.
 	cfgPath, err := config.DefaultLocalConfigPath()
 	if err != nil {
-		fmt.Errorf("Error while loading config: %s", err.Error())
+		fmt.Printf("Error while loading config: %s\n", err.Error())
 	}
 
 	fmt.Println("[INFO] Re-importing changed file: " + entry.FilePath)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description
### Changes

### 1. Add `vet` target to Makefile
Added `make vet` target that runs `go vet ./...` across all packages.
Enables standardized static analysis locally and in CI pipelines.

### 2. Fix `fmt.Errorf` result not used (`pkg/watcher/executor.go`)
`fmt.Errorf(...)` was called but its return value was discarded, silently
swallowing the error. Replaced with `fmt.Printf(...)` so the error is
actually printed to output.

### 3. Fix `DownloadArtifact` reading wrong body (`pkg/connectors/microcks_client.go`)
`io.ReadAll(req.Body)` was reading the request body instead of the response
body after the HTTP call completed. This caused the function to always return
empty data. Fixed to `io.ReadAll(resp.Body)`.

### 4. Fix function name typo (`pkg/connectors/microcks_client.go`)
Renamed `ensureValieOAuth2Context` → `ensureValidOAuth2Context`.
Updated both the function definition and its call site.

## Testing
- `make vet` now passes with no errors

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
NA