### PR TITLE
feat: add shell completion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ microcks [command] [flags]
 | `login`      | Log in to a Microcks instance using Keycloak credentials | [`login`](documentation/cmd/login.md)           |
 | `logout`     | Log out and remove authentication from a given context   | [`logout`](documentation/cmd/logout.md)         |
 | `context`    | Manage CLI contexts (list, use, delete)                  | [`context`](documentation/cmd/context.md)       |
+| `completion` | Generate shell completion scripts                         | [`completion`](documentation/cmd/completion.md) |
 | `start`      | Start a local Microcks instance via Docker/Podman        | [`start`](documentation/cmd/start.md)           |
 | `stop`       | Stop a local Microcks instance                           | [`stop`](documentation/cmd/stop.md)             |
 | `import`     | Import API spec files from local filesystem              | [`import`](documentation/cmd/import.md)         |

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,7 @@ func NewCommad() *cobra.Command {
 	command.AddCommand(NewContextCommand(&clientOpts))
 	command.AddCommand(NewLoginCommand(&clientOpts))
 	command.AddCommand(NewLogoutCommand(&clientOpts))
+	command.AddCommand(NewCompletionCommand())
 
 	defaultLocalConfigPath, err := config.DefaultLocalConfigPath()
 	errors.CheckError(err)

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/microcks/microcks-cli/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func NewCompletionCommand() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion scripts",
+		Long:  `Generate shell completion scripts`,
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			rootCmd := cmd.Root()
+			var err error
+
+			switch args[0] {
+			case "bash":
+				err = rootCmd.GenBashCompletion(cmd.OutOrStdout())
+			case "zsh":
+				err = rootCmd.GenZshCompletion(cmd.OutOrStdout())
+			case "fish":
+				err = rootCmd.GenFishCompletion(cmd.OutOrStdout(), true)
+			case "powershell":
+				err = rootCmd.GenPowerShellCompletion(cmd.OutOrStdout())
+			default:
+				err = fmt.Errorf("unsupported shell %q", args[0])
+			}
+			errors.CheckError(err)
+		},
+	}
+
+	return command
+}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -16,8 +16,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/microcks/microcks-cli/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +25,13 @@ func NewCompletionCommand() *cobra.Command {
 		Use:   "completion [bash|zsh|fish|powershell]",
 		Short: "Generate shell completion scripts",
 		Long:  `Generate shell completion scripts`,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		ValidArgs: []string{
+			"bash",
+			"zsh",
+			"fish",
+			"powershell",
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			rootCmd := cmd.Root()
 			var err error
@@ -41,8 +45,6 @@ func NewCompletionCommand() *cobra.Command {
 				err = rootCmd.GenFishCompletion(cmd.OutOrStdout(), true)
 			case "powershell":
 				err = rootCmd.GenPowerShellCompletion(cmd.OutOrStdout())
-			default:
-				err = fmt.Errorf("unsupported shell %q", args[0])
 			}
 			errors.CheckError(err)
 		},

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCompletionCommand(t *testing.T) {
+	cmd := NewCompletionCommand()
+
+	assert.Equal(t, "completion [bash|zsh|fish|powershell]", cmd.Use)
+	assert.Equal(t, "Generate shell completion scripts", cmd.Short)
+}
+
+func TestCompletionCommandRegistered(t *testing.T) {
+	cmd := NewCommad()
+
+	completionCmd, _, err := cmd.Find([]string{"completion"})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, completionCmd)
+	assert.Equal(t, "completion", completionCmd.Name())
+}
+
+func TestCompletionCommandGeneratesBash(t *testing.T) {
+	cmd := NewCommad()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"completion", "bash"})
+
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "completion for microcks")
+}

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -36,3 +36,16 @@ func TestCompletionCommandGeneratesBash(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "completion for microcks")
 }
+
+func TestCompletionCommandRejectsUnsupportedShell(t *testing.T) {
+	cmd := NewCommad()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"completion", "nushell"})
+
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid argument")
+}

--- a/documentation/cmd/completion.md
+++ b/documentation/cmd/completion.md
@@ -1,0 +1,40 @@
+## `microcks completion` - Generate shell completion scripts
+
+Generates shell completion scripts for supported shells.
+
+### Usage
+```bash
+microcks completion [bash|zsh|fish|powershell]
+```
+
+### Examples
+```bash
+# Generate bash completion
+microcks completion bash
+
+# Generate zsh completion
+microcks completion zsh
+
+# Generate fish completion
+microcks completion fish
+
+# Generate PowerShell completion
+microcks completion powershell
+```
+
+### Options
+| Flag         | Description     |
+| ------------ | --------------- |
+| `-h, --help` | help for completion |
+
+### Options Inherited from Parent Commands
+| Flag                     | Description                                 |
+| ------------------------ | ------------------------------------------- |
+| `--config`               | Path to Microcks config file                |
+| `--microcks-context`     | Name of the Microcks context to use         |
+| `--verbose`              | Produce dumps of HTTP exchanges             |
+| `--insecure-tls`         | Allow insecure HTTPS connections            |
+| `--caCerts`              | Comma-separated paths of CA cert files      |
+| `--keycloakClientId`     | Keycloak Realm Service Account ClientId     |
+| `--keycloakClientSecret` | Keycloak Realm Service Account ClientSecret |
+| `--microcksURL`          | Microcks API URL                            |

--- a/documentation/cmd/completion.md
+++ b/documentation/cmd/completion.md
@@ -1,13 +1,12 @@
-## `microcks completion` - Generate shell completion scripts
-
-Generates shell completion scripts for supported shells.
+## `microcks completion` – Generate Shell Completion Scripts
+Generates shell completion scripts for bash, zsh, fish, and PowerShell.
 
 ### Usage
 ```bash
 microcks completion [bash|zsh|fish|powershell]
 ```
 
-### Examples
+### Example
 ```bash
 # Generate bash completion
 microcks completion bash


### PR DESCRIPTION
Adds a visible completion command for bash, zsh, fish, and PowerShell. The root command already hides Cobra default completion command, so users currently do not have a documented way to generate shell completion scripts from the CLI.

For example, zsh users can run `microcks completion zsh > "${fpath[1]}/_microcks"` and then reload their shell completions. Bash, fish, and PowerShell users can generate the same kind of script for their shell.

The command writes completion output to the configured command output, which keeps it usable for tests and shell redirection. I also added command coverage and documented the new command in the README and command docs.

Tested with go test ./... and make build-binaries.

example output for zsh completion:
<img width="653" height="223" alt="image" src="https://github.com/user-attachments/assets/c6b2e7c9-4800-4aa0-ad4f-7be6a1138c29" />
