### PR TITLE
fix: honor saved insecure TLS setting

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -105,7 +105,7 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 			if keycloakUrl == "null" {
 				localConfig.UpsertServer(config.Server{
 					Server:         server,
-					InsecureTLS:    true,
+					InsecureTLS:    globalClientOpts.InsecureTLS,
 					KeycloakEnable: false,
 				})
 				fmt.Print("No login required...\n")
@@ -146,7 +146,7 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 
 				localConfig.UpsertServer(config.Server{
 					Server:         server,
-					InsecureTLS:    true,
+					InsecureTLS:    globalClientOpts.InsecureTLS,
 					KeycloakEnable: true,
 				})
 			}

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -151,8 +151,11 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 		c.Verbose = opts.Verbose
 	}
 
-	if config.InsecureTLS || len(config.CaCertPaths) > 0 {
+	if config.InsecureTLS || c.InsecureTLS || len(config.CaCertPaths) > 0 {
 		tlsConfig := config.CreateTLSConfig()
+		if c.InsecureTLS {
+			tlsConfig.InsecureSkipVerify = true
+		}
 		tr := &http.Transport{
 			TLSClientConfig: tlsConfig,
 		}


### PR DESCRIPTION
## Description

This fixes saved context TLS semantics. After login, later commands should use the same TLS policy that was persisted for that Microcks server.

`login` was always storing `insecureTLS: true`, even when `--insecure-tls` was not passed. At the same time, later commands were not honoring the saved context value when creating the HTTP client.

This PR makes the behavior consistent:

- persist `insecureTLS` from the actual login flag value
- honor the saved context TLS setting in `NewClient()`

## Testing

```sh
go test ./pkg/connectors
```

Also verified manually with a real Microcks uber container behind a self-signed HTTPS proxy.

Also follows up the changes from #180 . That fix made the current `--insecure-tls` flag apply to client construction. This PR covers the saved-context side: `login` now persists the flag value, and later context-based commands honor that persisted setting.

Fixes #286
