### PR TITLE
fix: return image pull stream errors

### DIFF
--- a/pkg/connectors/container_client.go
+++ b/pkg/connectors/container_client.go
@@ -112,7 +112,9 @@ func (cli *containerClient) CreateContainer(opts ContainerOpts) (string, error) 
 		return "", err
 	}
 	defer out.Close()
-	io.Copy(os.Stdout, out)
+	if err := copyImagePullOutput(out); err != nil {
+		return "", err
+	}
 
 	resp, err := cli.cli.ContainerCreate(
 		ctx,
@@ -147,4 +149,12 @@ func (cli *containerClient) StopContainer(containerId string) error {
 
 func (cli *containerClient) CloseClient() error {
 	return cli.cli.Close()
+}
+
+func copyImagePullOutput(out io.Reader) error {
+	_, err := io.Copy(os.Stdout, out)
+	if err != nil {
+		return fmt.Errorf("failed to read image pull output: %w", err)
+	}
+	return nil
 }

--- a/pkg/connectors/container_client_test.go
+++ b/pkg/connectors/container_client_test.go
@@ -1,0 +1,35 @@
+package connectors
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+type failingReader struct{}
+
+func (f failingReader) Read(p []byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func TestCopyImagePullOutputReturnsReadError(t *testing.T) {
+	err := copyImagePullOutput(failingReader{})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "failed to read image pull output") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCopyImagePullOutputSucceeds(t *testing.T) {
+	err := copyImagePullOutput(strings.NewReader(""))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+var _ io.Reader = failingReader{}


### PR DESCRIPTION
Checks the error returned while copying Docker image pull output during container creation. Before this, a read error from the pull stream was ignored and the command continued toward container creation, which could hide the real failure.

The copy logic is kept small and covered with connector tests for both success and read failure paths.

Tested with go test ./... and make build-binaries.