### PR TITLE
fix: remove dead duplicate Running status check in start command

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -47,11 +47,6 @@ microcks start --name [name of you container/instance]`,
 				instance = &config.Instance{}
 			}
 
-			if instance.Status == "Running" {
-				fmt.Printf("Microcks instance with name %s is already running", name)
-				return
-			}
-
 			switch instance.Status {
 			case "Running":
 				fmt.Printf("Microcks instance with name %s is already running", name)


### PR DESCRIPTION
The `if instance.Status == "Running"` check at line 50 already returns early, making the identical `case "Running":` inside the switch statement unreachable dead code.