### PR TITLE
fix: add auth config yaml keys

### DIFF
--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -56,9 +56,32 @@ type Instance struct {
 }
 
 type Auth struct {
-	Server       string
-	ClientId     string
-	ClientSecret string
+	Server       string `yaml:"server"`
+	ClientId     string `yaml:"clientId"`
+	ClientSecret string `yaml:"clientSecret"`
+}
+
+func (a *Auth) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw struct {
+		Server             string `yaml:"server"`
+		ClientId           string `yaml:"clientId"`
+		ClientSecret       string `yaml:"clientSecret"`
+		LegacyClientId     string `yaml:"clientid"`
+		LegacyClientSecret string `yaml:"clientsecret"`
+	}
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	if raw.ClientId == "" {
+		raw.ClientId = raw.LegacyClientId
+	}
+	if raw.ClientSecret == "" {
+		raw.ClientSecret = raw.LegacyClientSecret
+	}
+	a.Server = raw.Server
+	a.ClientId = raw.ClientId
+	a.ClientSecret = raw.ClientSecret
+	return nil
 }
 
 type WatchConfig struct {

--- a/pkg/config/localconfig_test.go
+++ b/pkg/config/localconfig_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestAuthYAMLTags(t *testing.T) {
+	cfg := LocalConfig{
+		Auths: []Auth{
+			{
+				Server:       "local",
+				ClientId:     "microcks-serviceaccount",
+				ClientSecret: "secret",
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "server: local")
+	require.Contains(t, string(data), "clientId: microcks-serviceaccount")
+	require.Contains(t, string(data), "clientSecret: secret")
+
+	var parsed LocalConfig
+	err = yaml.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+	require.Equal(t, cfg.Auths, parsed.Auths)
+}
+
+func TestAuthYAMLAcceptsLegacyKeys(t *testing.T) {
+	data := []byte(`auths:
+- server: local
+  clientid: microcks-serviceaccount
+  clientsecret: secret
+`)
+
+	var parsed LocalConfig
+	err := yaml.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+	require.Equal(t, []Auth{
+		{
+			Server:       "local",
+			ClientId:     "microcks-serviceaccount",
+			ClientSecret: "secret",
+		},
+	}, parsed.Auths)
+}


### PR DESCRIPTION
auth config now writes explicit YAML keys for server, clientId, and clientSecret, matching the style used by the rest of the local config structs.

I kept read support for the older lowercase clientid and clientsecret keys so existing config files continue to load. The new config test covers both the explicit keys and the legacy keys.

Tested with go test ./pkg/config -run TestAuthYAML -v, go test ./..., and make build-
binaries.

config tests covering the explicit auth YAML keys and the legacy lowercase keys.
<img width="526" height="162" alt="image" src="https://github.com/user-attachments/assets/d9aa9528-ef61-4f84-a9db-7427ef60d114" />
