### PR TITLE
fix: correct typo in login help example

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -40,7 +40,7 @@ func NewLoginCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command 
 		Use:   "login SERVER",
 		Short: "Login into Microcks instance",
 		Long:  "Login into Microcks instance",
-		Example: `microcks login http://locahost:8080
+		Example: `microcks login http://localhost:8080
 
 # Provide name to your logged in context (Default context name is server name)
 microcks login http://localhost:8080 --name

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,0 +1,2 @@
+[.ShellClassInfo]
+LocalizedResourceName=@microcks-cli,0

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,2 +1,1 @@
-[.ShellClassInfo]
-LocalizedResourceName=@microcks-cli,0
+


### PR DESCRIPTION
I observed that there is a typo in cmd/login.go
Fixed a typo in the login command help example:
- "locahost" → "localhost"
- initially it was , Example: `microcks login http://locahost:8080