### PR TITLE
Add `docker` in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,19 @@ updates:
     schedule:
       interval: monthly
       day: sunday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     rebase-strategy: disabled
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: monthly
       day: sunday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     rebase-strategy: disabled
   - package-ecosystem: docker
     directory: build/
     schedule:
       interval: monthly
       day: sunday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     rebase-strategy: disabled

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,19 @@ updates:
     schedule:
       interval: monthly
       day: sunday
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     rebase-strategy: disabled
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: monthly
       day: sunday
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
+    rebase-strategy: disabled
+  - package-ecosystem: docker
+    directory: build/
+    schedule:
+      interval: monthly
+      day: sunday
+    open-pull-requests-limit: 5
     rebase-strategy: disabled

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -14,12 +14,13 @@ on:
       - '*.md'
 permissions: 
   contents: read
-  id-token: write # needed for signing the images with GitHub OIDC Token
 
 jobs:
   build-verify-package:
     runs-on: ubuntu-latest
     environment: Build
+    permissions: 
+      id-token: write # needed for signing the images with GitHub OIDC Token
     steps:
       - name: Get current date
         id: date


### PR DESCRIPTION
Add `docker` in Dependabot, this will avoid to do it manually https://github.com/microcks/microcks-cli/pull/256.

_Note: Not directly related to this PR, but I took the opportunity to put the `write` permission at the job level and not root for the `build-verify.yml` workflow (already done for the other ones)._