### PR TITLE
fix : adding missing newlines in fmt.Printf calls

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -67,7 +67,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
+					fmt.Printf("Got error when invoking Microcks client retrieving config: %s\n", err)
 					os.Exit(1)
 				}
 
@@ -78,10 +78,10 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloak client: %s", err)
+						fmt.Printf("Got error when invoking Keycloak client: %s\n", err)
 						os.Exit(1)
 					}
-					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
+					//fmt.Printf("Retrieve OAuthToken: %s\n", oauthToken)
 				}
 
 				// Set Auth token.
@@ -110,7 +110,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
-					fmt.Printf("error %v", err)
+					fmt.Printf("error %v\n", err)
 					return
 				}
 			}
@@ -134,7 +134,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				// Try uploading this artifact.
 				msg, err := mc.UploadArtifact(f, mainArtifact)
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client importing Artifact: %s", err)
+					fmt.Printf("Got error when invoking Microcks client importing Artifact: %s\n", err)
 					os.Exit(1)
 				}
 				action := "discovered"

--- a/cmd/importDir.go
+++ b/cmd/importDir.go
@@ -146,7 +146,7 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			// Create client
 			mc, err := connectors.NewClient(*globalClientOpts)
 			if err != nil {
-				fmt.Printf("error %v", err)
+				fmt.Printf("error %v\n", err)
 				return
 			}
 

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -53,7 +53,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
+					fmt.Printf("Got error when invoking Microcks client retrieving config: %s\n", err)
 					os.Exit(1)
 				}
 
@@ -64,10 +64,10 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloak client: %s", err)
+						fmt.Printf("Got error when invoking Keycloak client: %s\n", err)
 						os.Exit(1)
 					}
-					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
+					//fmt.Printf("Retrieve OAuthToken: %s\n", oauthToken)
 				}
 
 				//Set Auth token
@@ -91,7 +91,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
-					fmt.Printf("error %v", err)
+					fmt.Printf("error %v\n", err)
 					return
 				}
 			}
@@ -120,7 +120,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 				// Try downloading the artifcat
 				msg, err := mc.DownloadArtifact(f, mainArtifact, secret)
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client importing Artifact: %s", err)
+					fmt.Printf("Got error when invoking Microcks client importing Artifact: %s\n", err)
 					os.Exit(1)
 				}
 				fmt.Printf("Microcks has discovered '%s'\n", msg)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -48,13 +48,13 @@ microcks start --name [name of you container/instance]`,
 			}
 
 			if instance.Status == "Running" {
-				fmt.Printf("Microcks instance with name %s is already running", name)
+				fmt.Printf("Microcks instance with name %s is already running\n", name)
 				return
 			}
 
 			switch instance.Status {
 			case "Running":
-				fmt.Printf("Microcks instance with name %s is already running", name)
+				fmt.Printf("Microcks instance with name %s is already running\n", name)
 				return
 			case "Exited":
 				containerClient, err := connectors.NewContainerClient(instance.Driver)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -121,7 +121,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
+					fmt.Printf("Got error when invoking Microcks client retrieving config: %s\n", err)
 					os.Exit(1)
 				}
 
@@ -132,10 +132,10 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloak client: %s", err)
+						fmt.Printf("Got error when invoking Keycloak client: %s\n", err)
 						os.Exit(1)
 					}
-					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
+					//fmt.Printf("Retrieve OAuthToken: %s\n", oauthToken)
 				}
 
 				// Then - launch the test on Microcks Server.
@@ -159,7 +159,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
-					fmt.Printf("error %v", err)
+					fmt.Printf("error %v\n", err)
 					return
 				}
 
@@ -172,10 +172,10 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			var testResultID string
 			testResultID, err := mc.CreateTestResult(serviceRef, testEndpoint, runnerType, secretName, waitForMilliseconds, filteredOperations, operationsHeaders, oAuth2Context)
 			if err != nil {
-				fmt.Printf("Got error when invoking Microcks client creating Test: %s", err)
+				fmt.Printf("Got error when invoking Microcks client creating Test: %s\n", err)
 				os.Exit(1)
 			}
-			//fmt.Printf("Retrieve TestResult ID: %s", testResultID)
+			//fmt.Printf("Retrieve TestResult ID: %s\n", testResultID)
 
 			// Finally - wait before checking and loop for some time
 			time.Sleep(1 * time.Second)
@@ -188,7 +188,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			for nowInMilliseconds() < future {
 				testResultSummary, err := mc.GetTestResult(testResultID)
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client check TestResult: %s", err)
+					fmt.Printf("Got error when invoking Microcks client check TestResult: %s\n", err)
 					os.Exit(1)
 				}
 				success = testResultSummary.Success

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,7 +76,7 @@ func DumpRequestIfRequired(name string, req *http.Request, body bool) {
 		if err != nil {
 			fmt.Println("Got error while dumping request out")
 		}
-		fmt.Printf("%s", dump)
+		fmt.Printf("%s\n", dump)
 	}
 }
 
@@ -88,7 +88,7 @@ func DumpResponseIfRequired(name string, resp *http.Response, body bool) {
 		if err != nil {
 			fmt.Println("Got error while dumping response")
 		}
-		fmt.Printf("%s", dump)
+		fmt.Printf("%s\n", dump)
 		if body {
 			fmt.Println("")
 		}


### PR DESCRIPTION
### Description

- Audited the entire codebase for `fmt.Print` and `fmt.Printf` calls missing a terminating newline.
- Added `\n` to various error, status, and discovery messages to ensure consistent terminal formatting.
- Fixed specific output in `pkg/connectors/container_client.go` where the "Stopping container..." log was missing a newline.
- Preserved interactive prompts in `cmd/login.go` (Username/Password) to maintain correct user input flow.

Fixes : #308 