### PR TITLE
 improve TestDeleteContext robustness and isolation using temporary directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,11 @@ build-binaries:
 .PHONY: build-watcher
 build-watcher:
 	go build -o ${DIST_DIR}/${BIN_NAME}-${WATCHER_NAME} ${PACKAGE}/watcher
+
+.PHONY: test
+test:
+	go test ./...
+
+.PHONY: fmt
+fmt:
+	go fmt ./...

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/microcks/microcks-cli/pkg/config"
@@ -36,9 +37,11 @@ users:
   auth-token: ""
   refresh-token: ""`
 
-const testConfigFilePath = "./testdata/local.config"
-
 func TestDeleteContext(t *testing.T) {
+	// create a temporary directory for the config file
+	tmpDir := t.TempDir()
+	testConfigFilePath := filepath.Join(tmpDir, "local.config")
+
 	//write the test config file
 	err := os.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
 	require.NoError(t, err)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -39,7 +39,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 		Run: func(cmd *cobra.Command, args []string) {
 			// Parse subcommand args first.
 			if len(args) == 0 {
-				fmt.Println("import command require <specificationFile1[:primary],specificationFile2[:primary]> args")
+				fmt.Println("import command requires <specificationFile1[:primary],specificationFile2[:primary]> args")
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}

--- a/pkg/config/localconfig_test.go
+++ b/pkg/config/localconfig_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalConfig_UpsertContext(t *testing.T) {
+	cfg := &LocalConfig{}
+	
+	ctx1 := ContextRef{Name: "ctx1", Server: "server1", User: "user1"}
+	cfg.UpsertContext(ctx1)
+	assert.Len(t, cfg.Contexts, 1)
+	assert.Equal(t, ctx1, cfg.Contexts[0])
+
+	// Update existing context
+	ctx1Updated := ContextRef{Name: "ctx1", Server: "server1-updated", User: "user1"}
+	cfg.UpsertContext(ctx1Updated)
+	assert.Len(t, cfg.Contexts, 1)
+	assert.Equal(t, ctx1Updated, cfg.Contexts[0])
+
+	// Add second context
+	ctx2 := ContextRef{Name: "ctx2", Server: "server2", User: "user2"}
+	cfg.UpsertContext(ctx2)
+	assert.Len(t, cfg.Contexts, 2)
+}
+
+func TestLocalConfig_RemoveContext(t *testing.T) {
+	cfg := &LocalConfig{
+		Contexts: []ContextRef{
+			{Name: "ctx1", Server: "server1"},
+			{Name: "ctx2", Server: "server2"},
+		},
+	}
+
+	server, removed := cfg.RemoveContext("ctx1")
+	assert.True(t, removed)
+	assert.Equal(t, "server1", server)
+	assert.Len(t, cfg.Contexts, 1)
+	assert.Equal(t, "ctx2", cfg.Contexts[0].Name)
+
+	server, removed = cfg.RemoveContext("non-existent")
+	assert.False(t, removed)
+	assert.Equal(t, "", server)
+	assert.Len(t, cfg.Contexts, 1)
+}
+
+func TestLocalConfig_ResolveContext(t *testing.T) {
+	cfg := &LocalConfig{
+		CurrentContext: "ctx1",
+		Contexts: []ContextRef{
+			{Name: "ctx1", Server: "server1", User: "user1"},
+		},
+		Servers: []Server{
+			{Name: "server1", Server: "server1"},
+		},
+		Users: []User{
+			{Name: "user1", AuthToken: "token1"},
+		},
+	}
+
+	// Resolve current context
+	ctx, err := cfg.ResolveContext("")
+	require.NoError(t, err)
+	assert.Equal(t, "ctx1", ctx.Name)
+	assert.Equal(t, "server1", ctx.Server.Server)
+	assert.Equal(t, "token1", ctx.User.AuthToken)
+
+	// Resolve specific context
+	ctx, err = cfg.ResolveContext("ctx1")
+	require.NoError(t, err)
+	assert.Equal(t, "ctx1", ctx.Name)
+
+	// Resolve non-existent context
+	ctx, err = cfg.ResolveContext("non-existent")
+	assert.Error(t, err)
+	assert.Nil(t, ctx)
+}
+
+func TestReadLocalConfig_Permissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config")
+	
+	configContent := `current-context: test
+contexts:
+- name: test
+  server: server1
+  user: user1
+servers:
+- name: server1
+  server: server1
+users:
+- name: user1`
+
+	// Create config with wrong permissions
+	err := os.WriteFile(path, []byte(configContent), 0755)
+	require.NoError(t, err)
+
+	_, err = ReadLocalConfig(path)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "incorrect permission flags")
+
+	// Fix permissions
+	err = os.Chmod(path, 0600)
+	require.NoError(t, err)
+
+	cfg, err := ReadLocalConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, "test", cfg.CurrentContext)
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type TestObject struct {
+	Name  string `yaml:"name"`
+	Value int    `yaml:"value"`
+}
+
+func TestUnmarshalLocalFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.yaml")
+	content := "name: test\nvalue: 123"
+	
+	err := os.WriteFile(path, []byte(content), 0644)
+	require.NoError(t, err)
+
+	var obj TestObject
+	err = UnmarshalLocalFile(path, &obj)
+	require.NoError(t, err)
+	assert.Equal(t, "test", obj.Name)
+	assert.Equal(t, 123, obj.Value)
+}
+
+func TestUnmarshal(t *testing.T) {
+	content := []byte("name: test\nvalue: 123")
+	var obj TestObject
+	err := Unmarshal(content, &obj)
+	require.NoError(t, err)
+	assert.Equal(t, "test", obj.Name)
+	assert.Equal(t, 123, obj.Value)
+}
+
+func TestMarshalLocalYAMLFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.yaml")
+	obj := TestObject{Name: "test", Value: 123}
+
+	err := MarshalLocalYAMLFile(path, &obj)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "name: test")
+	assert.Contains(t, string(data), "value: 123")
+}


### PR DESCRIPTION

### Description
This PR fixes a brittle test case in `cmd/context_test.go` where **TestDeleteContext** was failing on
  non-Unix-native filesystems (like **NTFS/FAT**). 

  The test previously relied on a static file path in ./testdata/, which caused issues when trying to set
  and verify restrictive file permissions (0600). By switching to t.TempDir(), the test is now isolated,
  environment-agnostic, and leaves no garbage files behind.

###   Changes
   - Removed hardcoded testConfigFilePath constant.
   - Added path/filepath to imports.
   - Updated TestDeleteContext to generate a unique temporary directory and path for each execution.



### Related issue(s) : #313

