### PR TITLE
improve TestDeleteContext using temporary directories

### DIFF
--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"os"
 	"testing"
-
+	"path/filepath"
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,9 +36,11 @@ users:
   auth-token: ""
   refresh-token: ""`
 
-const testConfigFilePath = "./testdata/local.config"
 
 func TestDeleteContext(t *testing.T) {
+	// create a temporary directory for the config file
+	tmpDir := t.TempDir()
+	testConfigFilePath := filepath.Join(tmpDir, "local.config")
 	//write the test config file
 	err := os.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
 	require.NoError(t, err)


### PR DESCRIPTION

### Description
This PR fixes a brittle test case in `cmd/context_test.go` where **TestDeleteContext** was failing on
  non-Unix-native filesystems (like **NTFS/FAT**). 

  The test previously relied on a static file path in ./testdata/, which caused issues when trying to set
  and verify restrictive file permissions (0600). By switching to t.TempDir(), the test is now isolated,
  environment-agnostic, and leaves no garbage files behind.

###   Changes
   - Removed hardcoded testConfigFilePath constant.
   - Added path/filepath to imports.
   - Updated TestDeleteContext to generate a unique temporary directory and path for each execution.



### Related issue(s) : #313

