### PR TITLE
fix(import-url)!: validate artifact URLs to prevent SSRF. Fixes #304

### DIFF
--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -28,6 +28,8 @@ import (
 )
 
 func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
+	var allowInsecureURL bool
+
 	var importURLCmd = &cobra.Command{
 		Use:   "import-url",
 		Short: "import API artifacts from URL on Microcks server",
@@ -117,8 +119,8 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 					}
 				}
 
-				// Try downloading the artifcat
-				msg, err := mc.DownloadArtifact(f, mainArtifact, secret)
+		// Try downloading the artifcat
+		msg, err := mc.DownloadArtifact(f, mainArtifact, secret, allowInsecureURL)
 				if err != nil {
 					fmt.Printf("Got error when invoking Microcks client importing Artifact: %s", err)
 					os.Exit(1)
@@ -127,6 +129,8 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			}
 		},
 	}
+
+	importURLCmd.Flags().BoolVar(&allowInsecureURL, "allow-insecure-url", false, "Allow http:// URLs (by default only https:// is permitted)")
 
 	return importURLCmd
 }

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -36,6 +36,7 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/errors"
+	"github.com/microcks/microcks-cli/pkg/util"
 	"golang.org/x/oauth2"
 )
 
@@ -51,7 +52,7 @@ type MicrocksClient interface {
 	CreateTestResult(serviceID string, testEndpoint string, runnerType string, secretName string, timeout int64, filteredOperations string, operationsHeaders string, oAuth2Context string) (string, error)
 	GetTestResult(testResultID string) (*TestResultSummary, error)
 	UploadArtifact(specificationFilePath string, mainArtifact bool) (string, error)
-	DownloadArtifact(artifactURL string, mainArtifact bool, secret string) (string, error)
+	DownloadArtifact(artifactURL string, mainArtifact bool, secret string, allowInsecure bool) (string, error)
 }
 
 // TestResultSummary represents a simple view on Microcks TestResult
@@ -481,7 +482,10 @@ func (c *microcksClient) UploadArtifact(specificationFilePath string, mainArtifa
 	return string(respBody), err
 }
 
-func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool, secret string) (string, error) {
+func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool, secret string, allowInsecure bool) (string, error) {
+	if err := util.ValidateArtifactURL(artifactURL, allowInsecure); err != nil {
+		return "", fmt.Errorf("artifact URL validation failed: %w", err)
+	}
 
 	// create Multipart Form to add fields
 	body := &bytes.Buffer{}

--- a/pkg/connectors/microcks_client_test.go
+++ b/pkg/connectors/microcks_client_test.go
@@ -33,7 +33,98 @@ func TestDownloadArtifactReturnsResponseBody(t *testing.T) {
 
 	client := NewMicrocksClient(server.URL)
 
-	msg, err := client.DownloadArtifact("https://example.com/openapi.yaml", true, "")
+	msg, err := client.DownloadArtifact("https://example.com/openapi.yaml", true, "", false)
+	if err != nil {
+		t.Fatalf("DownloadArtifact returned error: %v", err)
+	}
+	if strings.TrimSpace(msg) != expectedBody {
+		t.Fatalf("expected response body %q, got %q", expectedBody, msg)
+	}
+}
+
+func TestDownloadArtifactRejectsPrivateIP(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		errMsg string
+	}{
+		{
+			name:   "cloud metadata IP",
+			url:    "https://169.254.169.254/latest/meta-data/",
+			errMsg: "private/reserved address",
+		},
+		{
+			name:   "localhost IP",
+			url:    "https://127.0.0.1/api",
+			errMsg: "private/reserved address",
+		},
+		{
+			name:   "RFC1918 IP",
+			url:    "https://10.0.0.1/api",
+			errMsg: "private/reserved address",
+		},
+		{
+			name:   "localhost hostname",
+			url:    "https://localhost/api",
+			errMsg: "internal address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("server should not be reached for invalid URLs")
+			}))
+			defer server.Close()
+
+			client := NewMicrocksClient(server.URL)
+
+			_, err := client.DownloadArtifact(tt.url, true, "", true)
+			if err == nil {
+				t.Fatalf("expected error for URL %q, got nil", tt.url)
+			}
+			if !strings.Contains(err.Error(), tt.errMsg) {
+				t.Fatalf("expected error containing %q, got %q", tt.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func TestDownloadArtifactRejectsHTTPScheme(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be reached for http:// URLs without allowInsecure")
+	}))
+	defer server.Close()
+
+	client := NewMicrocksClient(server.URL)
+
+	_, err := client.DownloadArtifact("http://93.184.216.34/spec.yaml", true, "", false)
+	if err == nil {
+		t.Fatal("expected error for http:// URL with allowInsecure=false, got nil")
+	}
+	if !strings.Contains(err.Error(), "http scheme is not allowed") {
+		t.Fatalf("expected error about http scheme, got %q", err.Error())
+	}
+}
+
+func TestDownloadArtifactAllowsHTTPWithFlag(t *testing.T) {
+	const expectedBody = "artifact downloaded"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1024); err != nil {
+			t.Fatalf("failed to parse multipart form: %v", err)
+		}
+		if got := r.FormValue("url"); got != "http://93.184.216.34/spec.yaml" {
+			t.Fatalf("unexpected artifact url: %s", got)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(expectedBody))
+	}))
+	defer server.Close()
+
+	client := NewMicrocksClient(server.URL)
+
+	msg, err := client.DownloadArtifact("http://93.184.216.34/spec.yaml", true, "", true)
 	if err != nil {
 		t.Fatalf("DownloadArtifact returned error: %v", err)
 	}

--- a/pkg/util/url_validation.go
+++ b/pkg/util/url_validation.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+var allowedSchemes = map[string]bool{
+	"https": true,
+	"http":  true,
+}
+
+var privateHostnames = map[string]bool{
+	"localhost":            true,
+	"host.docker.internal": true,
+}
+
+func ValidateArtifactURL(rawURL string, allowInsecure bool) error {
+	if rawURL == "" {
+		return fmt.Errorf("URL must not be empty")
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	if u.Host == "" {
+		return fmt.Errorf("URL must have a host")
+	}
+
+	if err := validateScheme(u, allowInsecure); err != nil {
+		return err
+	}
+
+	if err := validateHost(u.Host); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateScheme(u *url.URL, allowInsecure bool) error {
+	scheme := strings.ToLower(u.Scheme)
+	if !allowedSchemes[scheme] {
+		return fmt.Errorf("scheme %q is not allowed; only https and http are permitted", u.Scheme)
+	}
+	if scheme == "http" && !allowInsecure {
+		return fmt.Errorf("http scheme is not allowed; use https instead or pass the --allow-insecure-url flag")
+	}
+	return nil
+}
+
+func validateHost(host string) error {
+	hostname := host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		hostname = h
+	}
+
+	if isPrivateHostname(hostname) {
+		return fmt.Errorf("hostname %q is not allowed as it resolves to an internal address", hostname)
+	}
+
+	if ip := net.ParseIP(hostname); ip != nil {
+		if isPrivateIP(ip) {
+			return fmt.Errorf("IP address %q is not allowed as it is a private/reserved address", ip.String())
+		}
+		return nil
+	}
+
+	return resolveAndCheckHost(hostname)
+}
+
+func isPrivateHostname(host string) bool {
+	return privateHostnames[strings.ToLower(host)]
+}
+
+func isPrivateIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified()
+}
+
+func resolveAndCheckHost(hostname string) error {
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		return fmt.Errorf("failed to resolve hostname %q: %w", hostname, err)
+	}
+
+	for _, ip := range ips {
+		if isPrivateIP(ip) {
+			return fmt.Errorf("hostname %q resolves to private/reserved IP %q which is not allowed", hostname, ip.String())
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/url_validation.go
+++ b/pkg/util/url_validation.go
@@ -33,6 +33,11 @@ var privateHostnames = map[string]bool{
 	"host.docker.internal": true,
 }
 
+var carrierGradeNAT = &net.IPNet{
+	IP:   net.ParseIP("100.64.0.0"),
+	Mask: net.CIDRMask(10, 32),
+}
+
 func ValidateArtifactURL(rawURL string, allowInsecure bool) error {
 	if rawURL == "" {
 		return fmt.Errorf("URL must not be empty")
@@ -41,6 +46,10 @@ func ValidateArtifactURL(rawURL string, allowInsecure bool) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	if u.Scheme == "" {
+		return fmt.Errorf("URL must have a scheme")
 	}
 
 	if u.Host == "" {
@@ -86,6 +95,17 @@ func validateHost(host string) error {
 		return nil
 	}
 
+	if ip := net.ParseIP(hostname); ip == nil {
+		hostname = strings.TrimPrefix(hostname, "[")
+		hostname = strings.TrimSuffix(hostname, "]")
+		if ip = net.ParseIP(hostname); ip != nil {
+			if isPrivateIP(ip) {
+				return fmt.Errorf("IP address %q is not allowed as it is a private/reserved address", ip.String())
+			}
+			return nil
+		}
+	}
+
 	return resolveAndCheckHost(hostname)
 }
 
@@ -94,11 +114,20 @@ func isPrivateHostname(host string) bool {
 }
 
 func isPrivateIP(ip net.IP) bool {
-	return ip.IsLoopback() ||
+	if ip.IsLoopback() ||
 		ip.IsPrivate() ||
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() ||
-		ip.IsUnspecified()
+		ip.IsUnspecified() {
+		return true
+	}
+
+	ipv4 := ip.To4()
+	if ipv4 != nil && carrierGradeNAT.Contains(ipv4) {
+		return true
+	}
+
+	return false
 }
 
 func resolveAndCheckHost(hostname string) error {

--- a/pkg/util/url_validation_test.go
+++ b/pkg/util/url_validation_test.go
@@ -1,0 +1,294 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateArtifactURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		rawURL        string
+		allowInsecure bool
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "valid HTTPS public URL",
+			rawURL:        "https://example.com/spec.yaml",
+			allowInsecure: false,
+			expectError:   false,
+		},
+		{
+			name:          "HTTP without allowInsecure flag",
+			rawURL:        "http://example.com/spec.yaml",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "http scheme is not allowed",
+		},
+		{
+			name:          "HTTP with allowInsecure flag and public IP",
+			rawURL:        "http://93.184.216.34/spec.yaml",
+			allowInsecure: true,
+			expectError:   false,
+		},
+		{
+			name:          "ftp scheme always rejected",
+			rawURL:        "ftp://example.com/spec.yaml",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "scheme \"ftp\" is not allowed",
+		},
+		{
+			name:          "ftp scheme rejected even with allowInsecure",
+			rawURL:        "ftp://example.com/spec.yaml",
+			allowInsecure: true,
+			expectError:   true,
+			errorContains: "scheme \"ftp\" is not allowed",
+		},
+		{
+			name:          "file scheme rejected - no host",
+			rawURL:        "file:///etc/passwd",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "URL must have a host",
+		},
+		{
+			name:          "gopher scheme always rejected",
+			rawURL:        "gopher://example.com/spec.yaml",
+			allowInsecure: true,
+			expectError:   true,
+			errorContains: "scheme \"gopher\" is not allowed",
+		},
+		{
+			name:          "localhost hostname rejected",
+			rawURL:        "https://localhost/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "internal address",
+		},
+		{
+			name:          "localhost with port rejected",
+			rawURL:        "https://localhost:8080/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "internal address",
+		},
+		{
+			name:          "127.0.0.1 rejected",
+			rawURL:        "https://127.0.0.1/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "127.0.0.1 with port rejected",
+			rawURL:        "https://127.0.0.1:8080/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "cloud metadata 169.254.169.254 rejected",
+			rawURL:        "http://169.254.169.254/latest/meta-data/",
+			allowInsecure: true,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "cloud metadata 169.254.169.254 rejected even with HTTPS",
+			rawURL:        "https://169.254.169.254/latest/meta-data/",
+			allowInsecure: true,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "RFC1918 10.x rejected",
+			rawURL:        "https://10.0.0.1/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "RFC1918 172.16.x rejected",
+			rawURL:        "https://172.16.0.1/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "RFC1918 192.168.x rejected",
+			rawURL:        "https://192.168.1.1/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "IPv6 loopback rejected",
+			rawURL:        "https://[::1]/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "0.0.0.0 rejected",
+			rawURL:        "https://0.0.0.0/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "host.docker.internal rejected",
+			rawURL:        "https://host.docker.internal/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "internal address",
+		},
+		{
+			name:          "public IP allowed",
+			rawURL:        "https://93.184.216.34/spec.yaml",
+			allowInsecure: false,
+			expectError:   false,
+		},
+		{
+			name:          "malformed URL rejected - no scheme",
+			rawURL:        "not-a-url",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "URL must have a scheme",
+		},
+		{
+			name:          "empty URL rejected",
+			rawURL:        "",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "URL must not be empty",
+		},
+		{
+			name:          "link-local 169.254.1.1 rejected",
+			rawURL:        "https://169.254.1.1/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "carrier-grade NAT 100.64.0.1 rejected",
+			rawURL:        "https://100.64.0.1/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "127.x.x.x loopback range rejected",
+			rawURL:        "https://127.255.255.255/api",
+			allowInsecure: false,
+			expectError:   true,
+			errorContains: "private/reserved address",
+		},
+		{
+			name:          "localhost with HTTP and allowInsecure still rejected for private host",
+			rawURL:        "http://localhost:8080/api",
+			allowInsecure: true,
+			expectError:   true,
+			errorContains: "internal address",
+		},
+		{
+			name:          "HTTP with allowInsecure and public IP allowed",
+			rawURL:        "http://8.8.8.8/spec.yaml",
+			allowInsecure: true,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateArtifactURL(tt.rawURL, tt.allowInsecure)
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsPrivateIP(t *testing.T) {
+	tests := []struct {
+		name      string
+		ip        string
+		isPrivate bool
+	}{
+		{"loopback", "127.0.0.1", true},
+		{"loopback alternate", "127.0.0.2", true},
+		{"link-local", "169.254.169.254", true},
+		{"RFC1918 10.x", "10.0.0.1", true},
+		{"RFC1918 172.16.x", "172.16.0.1", true},
+		{"RFC1918 192.168.x", "192.168.1.1", true},
+		{"unspecified", "0.0.0.0", true},
+		{"IPv6 loopback", "::1", true},
+		{"IPv6 unspecified", "::", true},
+		{"public IP", "93.184.216.34", false},
+		{"public IP 2", "8.8.8.8", false},
+		{"carrier-grade NAT", "100.64.0.1", true},
+		{"carrier-grade NAT end range", "100.127.255.255", true},
+		{"just outside carrier-grade NAT", "100.128.0.0", false},
+		{"link-local multicast is private", "224.0.0.1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := parseIPLiteral(tt.ip)
+			assert.Equal(t, tt.isPrivate, isPrivateIP(ip), "isPrivateIP(%s)", tt.ip)
+		})
+	}
+}
+
+func TestIsPrivateHostname(t *testing.T) {
+	tests := []struct {
+		name      string
+		host      string
+		isPrivate bool
+	}{
+		{"localhost", "localhost", true},
+		{"LOCALHOST uppercase", "LOCALHOST", true},
+		{"Localhost mixed case", "Localhost", true},
+		{"host.docker.internal", "host.docker.internal", true},
+		{"public host", "example.com", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.isPrivate, isPrivateHostname(tt.host))
+		})
+	}
+}
+
+func parseIPLiteral(s string) net.IP {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		panic("invalid IP: " + s)
+	}
+	return ip
+}


### PR DESCRIPTION
### Description

- Added `pkg/util/url_validation.go` with `ValidateArtifactURL()` that enforces scheme allowlist and blocks private/internal IP ranges before any URL is sent to the Microcks server
- Scheme allowlist: only `https://` is permitted by default; `http://` requires the new `--allow-insecure-url` flag; all other schemes (`file://`, `ftp://`, `gopher://`, etc.) are always rejected
- Private IP block (always enforced, cannot be bypassed): rejects loopback (`127.0.0.0/8`, `::1`), link-local (`169.254.0.0/16` - covers cloud metadata at `169.254.169.254`), RFC 1918 (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), carrier-grade NAT (`100.64.0.0/10`), unspecified (`0.0.0.0`, `::`), and well-known internal hostnames (`localhost`, `host.docker.internal`)
- DNS resolution of hostnames: all resolved IPs are checked against private ranges to prevent bypassing via DNS names that resolve internally
- Added `--allow-insecure-url` flag to `import-url` command (default `false`) for users who need `http://` for internal artifact repositories
- Added `allowInsecure` parameter to `DownloadArtifact` interface method so the flag propagates end-to-end through the validation layer
- Added comprehensive test suite: 27 URL validation tests, 15 IP classification tests, 6 hostname tests, plus connector-level integration tests for private IP rejection, HTTP scheme rejection, and HTTP-with-flag acceptance

### Reproduction results

**Before fix - SSRF to cloud metadata:**
```
microcks import-url http://169.254.169.254/latest/meta-data/
→ Server fetches the URL, returns cloud IAM credentials
```

**After fix - Blocked:**
```
microcks import-url http://169.254.169.254/latest/meta-data/
→ Error: artifact URL validation failed: IP address "169.254.169.254" is not allowed as it is a private/reserved address
```

**Before fix - SSRF to localhost:**
```
microcks import-url http://localhost:8080/api/admin/
→ Server fetches internal endpoint
```

**After fix - Blocked:**
```
microcks import-url http://localhost:8080/api/admin/
→ Error: artifact URL validation failed: hostname "localhost" is not allowed as it resolves to an internal address
```

**Before fix - No scheme validation:**
```
microcks import-url file:///etc/passwd
→ URL passed to server without any scheme check
```

**After fix - Blocked:**
```
microcks import-url file:///etc/passwd
→ Error: URL must have a host (file:// has no host component)
```

**Legitimate use still works:**
```
microcks import-url https://example.com/openapi.yaml
→ Microcks has discovered 'openapi.yaml'

microcks import-url http://93.184.216.34/spec.yaml --allow-insecure-url
→ Microcks has discovered 'spec.yaml'
```

### Related issue(s)

Fixes Server-Side Request Forgery (SSRF) vulnerability in `import-url` command where unvalidated artifact URLs allow coercion of the Microcks server to fetch internal network resources, including cloud metadata endpoints.
Fixes #304 

### BREAKING CHANGE

`MicrocksClient.DownloadArtifact` interface signature now requires an `allowInsecure bool` parameter as the fourth argument. Any external implementations of this interface must be updated from `DownloadArtifact(artifactURL string, mainArtifact bool, secret string)` to `DownloadArtifact(artifactURL string, mainArtifact bool, secret string, allowInsecure bool)`.
