### PR TITLE
fix(login): use isolated HTTP mux, eagerly bind port, and return errors from oauth2login. Fixes #312

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -266,8 +266,12 @@ func oauth2login(
 		completionChan <- ""
 	}
 
-	srv := &http.Server{Addr: "localhost:" + strconv.Itoa(port)}
-	http.HandleFunc("/auth/callback", callbackHandler)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/callback", callbackHandler)
+	srv := &http.Server{
+		Addr:    "localhost:" + strconv.Itoa(port),
+		Handler: mux,
+	}
 
 	var url string
 	opts := []oauth2.AuthCodeOption{}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strconv"

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -286,15 +286,15 @@ func oauth2login(
 		return "", "", fmt.Errorf("failed to bind callback port %s: %v (is another process using it?)", srv.Addr, listenErr)
 	}
 
-	fmt.Printf("Performing %s flow login: %s\n", "authorization_code", url)
-	time.Sleep(1 * time.Second)
-	ssoAuthFlow(url, ssoLaunchBrowser)
 	go func() {
 		log.Printf("Listen: %s\n", srv.Addr)
 		if serveErr := srv.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
 			completionChan <- fmt.Sprintf("Temporary HTTP server failed: %s", serveErr)
 		}
 	}()
+
+	fmt.Printf("Performing %s flow login: %s\n", "authorization_code", url)
+	ssoAuthFlow(url, ssoLaunchBrowser)
 	errMsg := <-completionChan
 	if errMsg != "" {
 		log.Fatal(errMsg)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -297,7 +297,10 @@ func oauth2login(
 	ssoAuthFlow(url, ssoLaunchBrowser)
 	errMsg := <-completionChan
 	if errMsg != "" {
-		log.Fatal(errMsg)
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer shutdownCancel()
+		_ = srv.Shutdown(shutdownCtx)
+		return "", "", fmt.Errorf("%s", errMsg)
 	}
 	fmt.Printf("Authentication successful\n")
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -189,7 +189,7 @@ func oauth2login(
 	port int,
 	oauth2conf *oauth2.Config,
 	ssoLaunchBrowser bool,
-) (string, string) {
+) (string, string, error) {
 	oauth2conf.ClientID = "microcks-app-js"
 	oauth2conf.RedirectURL = fmt.Sprintf("http://localhost:%d/auth/callback", port)
 
@@ -308,7 +308,7 @@ func oauth2login(
 	_ = srv.Shutdown(ctx)
 	log.Printf("Token: %s\n", tokenString)
 	log.Printf("Refresh Token: %s\n", refreshToken)
-	return tokenString, refreshToken
+	return tokenString, refreshToken, nil
 }
 
 func ssoAuthFlow(url string, ssoLaunchBrowser bool) {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -281,13 +281,18 @@ func oauth2login(
 	opts = append(opts, oauth2.SetAuthURLParam("code_challenge_method", "S256"))
 	url = oauth2conf.AuthCodeURL(stateNonce, opts...)
 
+	ln, listenErr := net.Listen("tcp", srv.Addr)
+	if listenErr != nil {
+		return "", "", fmt.Errorf("failed to bind callback port %s: %v (is another process using it?)", srv.Addr, listenErr)
+	}
+
 	fmt.Printf("Performing %s flow login: %s\n", "authorization_code", url)
 	time.Sleep(1 * time.Second)
 	ssoAuthFlow(url, ssoLaunchBrowser)
 	go func() {
 		log.Printf("Listen: %s\n", srv.Addr)
-		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-			log.Fatalf("Temporary HTTP server failed: %s", err)
+		if serveErr := srv.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
+			completionChan <- fmt.Sprintf("Temporary HTTP server failed: %s", serveErr)
 		}
 	}()
 	errMsg := <-completionChan

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -130,7 +130,8 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 					kc := connectors.NewKeycloakClient(keycloakUrl, "", "")
 					oauth2conf, err := kc.GetOIDCConfig()
 					errors.CheckError(err)
-					authToken, refreshToken = oauth2login(ctx, ssoProt, oauth2conf, ssoLaunchBrowser)
+					authToken, refreshToken, err = oauth2login(ctx, ssoProt, oauth2conf, ssoLaunchBrowser)
+					errors.CheckError(err)
 					authCfg.ClientId = "microcks-app-js"
 				}
 

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func findAvailablePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to find available port: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func makeTestOAuth2Config(port int) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:    "microcks-app-js",
+		RedirectURL: fmt.Sprintf("http://localhost:%d/auth/callback", port),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "http://localhost:0/auth/realms/microcks/protocol/openid-connect/auth",
+			TokenURL: "http://localhost:0/auth/realms/microcks/protocol/openid-connect/token",
+		},
+		Scopes: []string{"openid"},
+	}
+}
+
+func TestPortHijackDetection(t *testing.T) {
+	port := findAvailablePort(t)
+
+	rogueLn, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
+		t.Fatalf("failed to start rogue listener: %v", err)
+	}
+	defer rogueLn.Close()
+
+	rogueSrv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("ROGUE SERVER intercepted request: %s", r.URL)
+		w.WriteHeader(200)
+		fmt.Fprint(w, "attacker captured route")
+	})}
+	go rogueSrv.Serve(rogueLn)
+	defer rogueSrv.Shutdown(context.Background())
+
+	oauth2conf := makeTestOAuth2Config(port)
+
+	doneCh := make(chan error, 1)
+	go func() {
+		_, _, err := oauth2login(context.Background(), port, oauth2conf, false)
+		doneCh <- err
+	}()
+
+	select {
+	case err := <-doneCh:
+		if err == nil {
+			t.Fatal("oauth2login should NOT have returned nil error when the port is hijacked")
+		}
+		errMsg := err.Error()
+		if !strings.Contains(errMsg, "failed to bind callback port") &&
+			!strings.Contains(errMsg, "address already in use") {
+			t.Fatalf("expected port-bind error, got: %s", errMsg)
+		}
+		t.Logf("PASS: Port hijack detected with clear error: %s", errMsg)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: oauth2login did not detect port hijack within 5s")
+	}
+}
+
+func TestGlobalMuxNotPolluted(t *testing.T) {
+	hasCallbackBefore := isRouteInDefaultServeMux("/auth/callback")
+
+	port := findAvailablePort(t)
+	oauth2conf := makeTestOAuth2Config(port)
+
+	go func() {
+		oauth2login(context.Background(), port, oauth2conf, false)
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	hasCallbackAfter := isRouteInDefaultServeMux("/auth/callback")
+
+	if hasCallbackAfter && !hasCallbackBefore {
+		t.Fatal("DefaultServeMux was polluted! /auth/callback route was registered globally " +
+			"but should use an isolated mux.")
+	}
+	t.Logf("PASS: DefaultServeMux not polluted (/auth/callback in global mux: before=%v, after=%v)",
+		hasCallbackBefore, hasCallbackAfter)
+}
+
+func isRouteInDefaultServeMux(path string) bool {
+	_, pattern := http.DefaultServeMux.Handler(&http.Request{
+		URL:    &url.URL{Path: path},
+		Method: "GET",
+	})
+	return pattern != ""
+}
+
+func TestEagerPortBindBeforeBrowser(t *testing.T) {
+	port := findAvailablePort(t)
+	oauth2conf := makeTestOAuth2Config(port)
+
+	go func() {
+		oauth2login(context.Background(), port, oauth2conf, false)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	if err == nil {
+		ln.Close()
+		t.Fatal("Port was NOT bound shortly after oauth2login started — " +
+			"server should eagerly bind before opening the browser")
+	}
+
+	t.Log("PASS: Port was already bound early (eager bind works)")
+}
+
+func TestServerShutdownOnErrorPath(t *testing.T) {
+	port := findAvailablePort(t)
+	oauth2conf := makeTestOAuth2Config(port)
+
+	go func() {
+		oauth2login(context.Background(), port, oauth2conf, false)
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	callbackURL := fmt.Sprintf("http://localhost:%d/auth/callback?error=access_denied&error_description=User+cancelled", port)
+	_, _ = http.Get(callbackURL)
+
+	time.Sleep(2 * time.Second)
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
+		t.Fatalf("Server port still bound after error path — server was not shut down properly: %v", err)
+	}
+	ln.Close()
+	t.Log("PASS: Server port released after error path (shutdown on error works)")
+}
+
+func TestConcurrentIsolatedMuxCalls(t *testing.T) {
+	port1 := findAvailablePort(t)
+	port2 := findAvailablePort(t)
+
+	oauth2conf1 := makeTestOAuth2Config(port1)
+	oauth2conf2 := makeTestOAuth2Config(port2)
+
+	go func() {
+		oauth2login(context.Background(), port1, oauth2conf1, false)
+	}()
+
+	go func() {
+		oauth2login(context.Background(), port2, oauth2conf2, false)
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	ln1, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port1))
+	if err == nil {
+		ln1.Close()
+		t.Fatal("Port 1 was NOT bound — server should eagerly bind")
+	}
+	ln2, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port2))
+	if err == nil {
+		ln2.Close()
+		t.Fatal("Port 2 was NOT bound — server should eagerly bind")
+	}
+
+	t.Log("PASS: Concurrent oauth2login calls both bound their ports independently (isolated muxes)")
+}


### PR DESCRIPTION
### Description

- Replaced `http.HandleFunc` (process-global `http.DefaultServeMux`) with an isolated `http.NewServeMux` per `oauth2login` call, eliminating handler pollution across repeated invocations and race conditions on the shared global mux
- Changed `oauth2login` to eagerly bind the callback port via `net.Listen` before opening the browser, so port hijack attempts are detected immediately with a clear error message instead of crashing inside a goroutine after the OAuth flow has already started
- Reordered server startup: the callback HTTP server now starts before `ssoAuthFlow` opens the browser, guaranteeing the server is ready when the browser redirects back
- Changed `oauth2login` signature from `(string, string)` to `(string, string, error)`, replacing `log.Fatal`/`log.Fatalf` calls with returned errors so the caller controls error handling and the function is testable
- Added `srv.Shutdown` on the error path before returning, ensuring the callback server port is released even when the OAuth flow fails
- Removed the `time.Sleep(1 * time.Second)` hack that previously tried to paper over the race between server startup and browser redirect

### Reproduction results

**Before fix - Port hijack:**
A rogue process listening on port 58085 before `login --sso` causes `log.Fatalf` inside a goroutine after the browser is already open. The user sees a confusing crash and the OAuth callback is silently routed to the attacker.

**After fix - Port hijack detected early:**
`oauth2login` returns `error: "failed to bind callback port localhost:58085: listen tcp 127.0.0.1:58085: bind: address already in use (is another process using it?)"` immediately - no browser opened, no OAuth flow started.

**Before fix - Global mux pollution:**
`http.HandleFunc("/auth/callback", ...)` registers the route on `http.DefaultServeMux` permanently. A second `login --sso` call overwrites the first handler. In the same binary, this route interferes with any other HTTP serving.

**After fix - Isolated mux:**
Each `oauth2login` call creates its own `http.NewServeMux`. `/auth/callback` is never registered on `http.DefaultServeMux`. Concurrent and sequential calls are fully independent.

**Before fix - Server port leaked on error:**
When the callback receives an error (e.g. `access_denied`), `log.Fatal` is called without shutting down the server, leaving the port bound until the process exits.

**After fix - Clean shutdown on error:**
`srv.Shutdown` is called before returning the error, releasing the port immediately.

**Test suite (5 tests, all passing):**

| Test | Verifies |
|------|----------|
| `TestPortHijackDetection` | Rogue listener → clear early abort with descriptive error |
| `TestGlobalMuxNotPolluted` | `/auth/callback` not in `DefaultServeMux` after call |
| `TestEagerPortBindBeforeBrowser` | Port bound before browser would open |
| `TestServerShutdownOnErrorPath` | Port released after error callback |
| `TestConcurrentIsolatedMuxCalls` | Two concurrent calls bind independent ports |

### Related issue(s)

Fixes race condition, global mux pollution, and port hijack vulnerability in OAuth2 SSO callback server as described in issue 
Fixes #312 .

### BREAKING CHANGE

`oauth2login` now returns `(string, string, error)` instead of `(string, string)`. Any callers of this function must handle the returned error.
