### PR TITLE
fix: return errors instead of panicking on response parsing in connectors

### DIFF
--- a/pkg/connectors/keycloak_client.go
+++ b/pkg/connectors/keycloak_client.go
@@ -97,16 +97,16 @@ func (c *keycloakClient) ConnectAndGetToken() (string, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to read Keycloak token response: %w", err)
 	}
 
 	var openIDResp map[string]interface{}
 	if err := json.Unmarshal(body, &openIDResp); err != nil {
-		panic(err)
+		return "", fmt.Errorf("failed to parse Keycloak token response: %w", err)
 	}
 
 	accessToken := openIDResp["access_token"].(string)
-	return accessToken, err
+	return accessToken, nil
 }
 
 func (c *keycloakClient) GetOIDCConfig() (*oauth2.Config, error) {
@@ -127,12 +127,12 @@ func (c *keycloakClient) GetOIDCConfig() (*oauth2.Config, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return nil, fmt.Errorf("failed to read OIDC config response: %w", err)
 	}
 
 	var openIDResp map[string]interface{}
 	if err := json.Unmarshal(body, &openIDResp); err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to parse OIDC config response: %w", err)
 	}
 
 	authURL := openIDResp["authorization_endpoint"].(string)
@@ -174,12 +174,12 @@ func (c *keycloakClient) ConnectAndGetTokenAndRefreshToken(username, password st
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", "", fmt.Errorf("failed to read Keycloak token response: %w", err)
 	}
 
 	var openIDResp map[string]interface{}
 	if err := json.Unmarshal(body, &openIDResp); err != nil {
-		panic(err)
+		return "", "", fmt.Errorf("failed to parse Keycloak token response: %w", err)
 	}
 
 	authToken := openIDResp["access_token"].(string)

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -228,12 +228,12 @@ func (c *microcksClient) GetKeycloakURL() (string, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to read Keycloak config response: %w", err)
 	}
 
 	var configResp map[string]interface{}
 	if err := json.Unmarshal(body, &configResp); err != nil {
-		panic(err)
+		return "", fmt.Errorf("failed to parse Keycloak config response: %w", err)
 	}
 
 	// Retrieve auth server url and realm name.
@@ -367,16 +367,16 @@ func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string,
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to read create test result response: %w", err)
 	}
 
 	var createTestResp map[string]interface{}
 	if err := json.Unmarshal(body, &createTestResp); err != nil {
-		panic(err)
+		return "", fmt.Errorf("failed to parse create test result response: %w", err)
 	}
 
 	testID := createTestResp["id"].(string)
-	return testID, err
+	return testID, nil
 }
 
 func (c *microcksClient) GetTestResult(testResultID string) (*TestResultSummary, error) {
@@ -406,7 +406,7 @@ func (c *microcksClient) GetTestResult(testResultID string) (*TestResultSummary,
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return nil, fmt.Errorf("failed to read test result response: %w", err)
 	}
 
 	result := TestResultSummary{}
@@ -434,7 +434,7 @@ func (c *microcksClient) UploadArtifact(specificationFilePath string, mainArtifa
 	}
 	_, err = io.Copy(part, file)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to copy file content into multipart body: %w", err)
 	}
 
 	// Add the mainArtifact flag to request.
@@ -470,7 +470,7 @@ func (c *microcksClient) UploadArtifact(specificationFilePath string, mainArtifa
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to read upload artifact response: %w", err)
 	}
 
 	// Raise exception if not created.
@@ -478,7 +478,7 @@ func (c *microcksClient) UploadArtifact(specificationFilePath string, mainArtifa
 		return "", errs.New(string(respBody))
 	}
 
-	return string(respBody), err
+	return string(respBody), nil
 }
 
 func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool, secret string) (string, error) {
@@ -524,7 +524,7 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to read download artifact response: %w", err)
 	}
 
 	// Raise exception if not created.
@@ -532,7 +532,7 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 		return "", errs.New(string(respBody))
 	}
 
-	return string(respBody), err
+	return string(respBody), nil
 }
 
 func ensureValidOperationsList(filteredOperations string) bool {


### PR DESCRIPTION
### Summary
Replaces 12 panic(err) / panic(err.Error()) calls in pkg/connectors/{microcks,keycloak}_client.go with wrapped fmt.Errorf("...: %w", err) returns.
Cleans up three return x, err sites where err was guaranteed nil after the change (now return x, nil).
Continues the pattern established by #258, #259 and commit f9f282c, which fixed the same anti-pattern in one location each.
fixes #318 

### Why
Every affected method already returns error. Panicking on io.ReadAll / json.Unmarshal / io.Copy failure means a malformed or truncated response from Microcks/Keycloak crashes the CLI with a stack trace instead of surfacing a clean error. This is most visible when a reverse proxy or gateway returns HTML on an otherwise-2xx request, or when the connection drops mid-body.

### Test plan
 

- [x] go build ./... passes
- [x]  go test ./pkg/connectors/... passes (existing TestDownloadArtifactReturnsResponseBody still green)
- [ ]  Manual: point CLI at a server returning HTML on /api/keycloak/config — previously panicked, now returns a wrapped error