### PR TITLE
test: use temporary config file in context delete test

### DIFF
--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/microcks/microcks-cli/pkg/config"
@@ -36,15 +37,13 @@ users:
   auth-token: ""
   refresh-token: ""`
 
-const testConfigFilePath = "./testdata/local.config"
-
 func TestDeleteContext(t *testing.T) {
-	//write the test config file
-	err := os.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
+	testConfigFilePath := filepath.Join(t.TempDir(), "local.config")
+
+	// write the test config file
+	err := os.WriteFile(testConfigFilePath, []byte(testConfig), 0o600)
 	require.NoError(t, err)
 
-	err = os.Chmod(testConfigFilePath, 0o600)
-	require.NoError(t, err, "Could not change the file permission to 0600 %v", err)
 	localCfg, err := config.ReadLocalConfig(testConfigFilePath)
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:8083", localCfg.CurrentContext)


### PR DESCRIPTION
## Summary

This PR fixes `TestDeleteContext` by updating it to use a temporary config file created with `t.TempDir()` instead of writing to `./testdata/local.config`.

On a clean checkout, `cmd/testdata` may not exist, which causes the test to fail with:


open ./testdata/local.config: no such file or directory

The test behavior remains unchanged, but it no longer depends on an untracked local directory.

Fixes #313
Related to #321



## Test plan
 go test ./cmd/... -run TestDeleteContext -v
 go test ./...
 go test ./cmd/... -count=3
 make build-local
