### PR TITLE
docs(cli): fix microcks start help descriptions

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -143,10 +143,10 @@ microcks start --name [name of you container/instance]`,
 			fmt.Printf("Microcks started successfully at %s\n", server)
 		},
 	}
-	startCmd.Flags().StringVar(&name, "name", "microcks", "name for you microcks instance")
-	startCmd.Flags().StringVar(&hostPort, "port", "8585", "")
+	startCmd.Flags().StringVar(&name, "name", "microcks", "name for your Microcks instance")
+	startCmd.Flags().StringVar(&hostPort, "port", "8585", "Host port to expose Microcks")
 	startCmd.Flags().StringVar(&imageName, "image", "quay.io/microcks/microcks-uber:latest-native", "image which will be used to create a container")
-	startCmd.Flags().BoolVar(&autoRemove, "rm", false, "mimic of '--rm' flag of dokcer to automatically remove the container when it exits")
+	startCmd.Flags().BoolVar(&autoRemove, "rm", false, "mimic of '--rm' flag of Docker to automatically remove the container when it exits")
 	startCmd.Flags().StringVar(&driver, "driver", "docker", "use --driver to change driver from docker to podman")
 	return startCmd
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
## Summary

This PR improves the help text for `microcks start`.

Changes:

- Adds a clear description for `--port`
- Fixes "you microcks instance" to "your Microcks instance"
- Fixes "dokcer" to "Docker"

No command behavior is changed.

Fixes #335

## Test plan

- [x] `make build-local`
- [x] `./build/dist/microcks start --help`
- [x] `go test ./...`

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->