### PR TITLE
fix typo in DownloadArtifact: was reading req.Body instead of resp.Body

### DIFF
--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -510,7 +510,7 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 	req.Header.Set("Authorization", "Bearer "+c.AuthToken)
 
 	// Dump request if verbose required.
-	config.DumpRequestIfRequired("Microcks for uploading artifact", req, true)
+	config.DumpRequestIfRequired("Microcks for downloading artifact", req, true)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -519,9 +519,9 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 	defer resp.Body.Close()
 
 	// Dump response if verbose required.
-	config.DumpResponseIfRequired("Microcks for uploading artifact", resp, true)
+	config.DumpResponseIfRequired("Microcks for downloading artifact", resp, true)
 
-	respBody, err := io.ReadAll(req.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
After `httpClient.Do(req)` returns, `req.Body` is already consumed - so `io.ReadAll(req.Body)` always gives back empty bytes. Swapped it to `resp.Body` so we actually get the server's response back.

Also fixed the two log labels that still said "uploading artifact" inside the download path (copy-paste leftover from `UploadArtifact`).

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- `DownloadArtifact` was calling `io.ReadAll(req.Body)` instead of `io.ReadAll(resp.Body)`, meaning the server response was always silently discarded
- On a 201 the CLI printed `Microcks has discovered ''` (empty string - service name was never captured)
- On any non-201 the error message was blank, so CI would fail with `Got error when invoking Microcks client importing Artifact:` and no further detail
- Fixed the two `DumpRequestIfRequired` / `DumpResponseIfRequired` log labels in `DownloadArtifact` that still said `"uploading artifact"` (copy-pasted from `UploadArtifact` and never updated)

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Fixes #337
