### PR TITLE
feat(test): add --output-format flag for GitHub Actions annotations

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -29,7 +29,8 @@ import (
 )
 
 var (
-	runnerChoices = map[string]bool{"HTTP": true, "SOAP_HTTP": true, "SOAP_UI": true, "POSTMAN": true, "OPEN_API_SCHEMA": true, "ASYNC_API_SCHEMA": true, "GRPC_PROTOBUF": true, "GRAPHQL_SCHEMA": true}
+	runnerChoices       = map[string]bool{"HTTP": true, "SOAP_HTTP": true, "SOAP_UI": true, "POSTMAN": true, "OPEN_API_SCHEMA": true, "ASYNC_API_SCHEMA": true, "GRPC_PROTOBUF": true, "GRAPHQL_SCHEMA": true}
+	outputFormatChoices = map[string]bool{"plain": true, "github-actions": true}
 )
 
 func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
@@ -39,6 +40,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 		filteredOperations string
 		operationsHeaders  string
 		oAuth2Context      string
+		outputFormat       string
 	)
 	var testCmd = &cobra.Command{
 
@@ -71,6 +73,10 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			}
 			if _, validChoice := runnerChoices[runnerType]; !validChoice {
 				fmt.Println("<runner> should be one of: HTTP, SOAP, SOAP_UI, POSTMAN, OPEN_API_SCHEMA, ASYNC_API_SCHEMA, GRPC_PROTOBUF, GRAPHQL_SCHEMA")
+				os.Exit(1)
+			}
+			if _, validChoice := outputFormatChoices[outputFormat]; !validChoice {
+				fmt.Println("--output-format should be one of: plain, github-actions")
 				os.Exit(1)
 			}
 
@@ -205,6 +211,14 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 			fmt.Printf("Full TestResult details are available here: %s/#/tests/%s \n", serverAddr, testResultID)
 
+			if outputFormat == "github-actions" {
+				if success {
+					fmt.Printf("::notice title=Test Passed::%s tests PASSED for endpoint %s\n", serviceRef, testEndpoint)
+				} else {
+					fmt.Printf("::error title=Test Failed::%s tests FAILED for endpoint %s\n", serviceRef, testEndpoint)
+				}
+			}
+
 			if !success {
 				os.Exit(1)
 			}
@@ -216,6 +230,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 	testCmd.Flags().StringVar(&filteredOperations, "filteredOperations", "", "List of operations to launch a test for")
 	testCmd.Flags().StringVar(&operationsHeaders, "operationsHeaders", "", "Override of operations headers as JSON string")
 	testCmd.Flags().StringVar(&oAuth2Context, "oAuth2Context", "", "Spec of an OAuth2 client context as JSON string")
+	testCmd.Flags().StringVar(&outputFormat, "output-format", "plain", "Output format for test results: plain, github-actions")
 
 	return testCmd
 }


### PR DESCRIPTION
- Add `--output-format` flag to the `test` command with two values: `plain` (default) and `github-actions`
- `plain` keeps existing behavior unchanged
- `github-actions` emits GitHub Actions workflow commands for inline PR annotations on pass/fail
- Add validation that rejects unknown `--output-format` values with a clear error message

**Note:** Current `TestResultSummary` only carries overall success/failure — no per-operation breakdown.
Per-operation annotations would require extending `TestResultSummary` to include `testCaseResults`.
Happy to follow up in a separate PR if that is the preferred direction.

Fixes #332
