### PR TITLE
Fix/watcher spelling and path logic

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCommad() *cobra.Command {
+func NewCommand() *cobra.Command {
 
 	var clientOpts connectors.ClientOptions
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -131,6 +131,9 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 					}
 				}
 
+				// Normalize file path to keep upload and watch config paths consistent.
+				f = strings.TrimPrefix(f, "./")
+
 				// Try uploading this artifact.
 				msg, err := mc.UploadArtifact(f, mainArtifact)
 				if err != nil {
@@ -154,11 +157,6 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 						watchCfg = &config.WatchConfig{}
 					}
 
-					// Normalize file path to match the watcher fsnotify events format.
-					if strings.HasPrefix(f, "./") {
-						f = strings.TrimPrefix(f, "./")
-					}
-
 					// Upsert entry.
 					watchCfg.UpsertEntry(config.WatchEntry{
 						FilePath:     f,
@@ -177,7 +175,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				watchFile, err := config.DefaultLocalWatchPath()
 				errors.CheckError(err)
 
-				wm, err := watcher.NewWatchManger(watchFile)
+				wm, err := watcher.NewWatchManager(watchFile)
 				errors.CheckError(err)
 
 				fmt.Println("Watch mode enabled - microcks-watcher started...")

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	command := cmd.NewCommad()
+	command := cmd.NewCommand()
 	if err := command.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/pkg/watcher/executor.go
+++ b/pkg/watcher/executor.go
@@ -12,7 +12,8 @@ func TriggerImport(entry config.WatchEntry) {
 	// Retrieve config to get client options.
 	cfgPath, err := config.DefaultLocalConfigPath()
 	if err != nil {
-		fmt.Errorf("Error while loading config: %s", err.Error())
+		fmt.Printf("Error while loading config: %s\n", err.Error())
+		return
 	}
 
 	fmt.Println("[INFO] Re-importing changed file: " + entry.FilePath)

--- a/pkg/watcher/watchManager.go
+++ b/pkg/watcher/watchManager.go
@@ -17,7 +17,7 @@ type WatchManager struct {
 	lock         sync.Mutex
 }
 
-func NewWatchManger(configPath string) (*WatchManager, error) {
+func NewWatchManager(configPath string) (*WatchManager, error) {
 	fw, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err

--- a/watcher/main.go
+++ b/watcher/main.go
@@ -12,7 +12,7 @@ func main() {
 	watchFile, err := config.DefaultLocalWatchPath()
 	errors.CheckError(err)
 
-	wm, err := watcher.NewWatchManger(watchFile)
+	wm, err := watcher.NewWatchManager(watchFile)
 	errors.CheckError(err)
 
 	fmt.Println("[INFO] microcks-watcher started...")


### PR DESCRIPTION
### Description

This pull request fixes several code quality and logic issues in the Microcks CLI.

Changes included:

* Fixed a typo in the CLI command constructor function by renaming `NewCommad()` to `NewCommand()`.
* Fixed a naming typo in the watcher constructor by renaming `NewWatchManger()` to `NewWatchManager()` for consistency with the struct name.
* Corrected the order of file path normalization in the `import` command so that `./` prefixes are removed **before** calling `UploadArtifact()`. This ensures consistent paths between uploaded artifacts and watcher configuration.

These fixes improve compilation reliability, code readability, and correct watcher behavior in watch mode.

### Changes

1. **Command Constructor Fix**

   * Renamed `NewCommad()` → `NewCommand()`
   * Updated all references to match the corrected function name.

2. **WatchManager Constructor Fix**

   * Renamed `NewWatchManger()` → `NewWatchManager()`
   * Updated all call sites accordingly.

3. **File Path Normalization Fix**

   * Moved path normalization logic before the `UploadArtifact()` call.
   * Ensures consistent artifact paths between upload and watcher configuration.

### Testing

* Built the CLI locally to verify compilation succeeds.
* Verified that the `import` command works correctly with normalized file paths.
* Confirmed that watcher configuration now uses consistent file paths.

### Related issue(s)

Fixes #342
