### PR TITLE
refactor(cmd): replace os.Exit/log.Fatalf with RunE and add Args validators

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -27,9 +27,10 @@ func NewCommad() *cobra.Command {
 	var clientOpts connectors.ClientOptions
 
 	command := &cobra.Command{
-		Use:          "microcks",
-		Short:        "A CLI tool for Microcks",
-		SilenceUsage: true,
+		Use:           "microcks",
+		Short:         "A CLI tool for Microcks",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -35,15 +34,8 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 		Use:   "import",
 		Short: "import API artifacts on Microcks server",
 		Long:  `import API artifacts on Microcks server`,
-		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			// Parse subcommand args first.
-			if len(args) == 0 {
-				fmt.Println("import command require <specificationFile1[:primary],specificationFile2[:primary]> args")
-				cmd.HelpFunc()(cmd, args)
-				os.Exit(1)
-			}
-
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
 			specificationFiles := args[0]
 
 			// Initialize config from command options.
@@ -54,8 +46,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 			// Read local config file in case we need some context info.
 			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			// Prepare Microcks client.
@@ -67,8 +58,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
-					os.Exit(1)
+					return fmt.Errorf("got error when invoking Microcks client retrieving config: %w", err)
 				}
 
 				var oauthToken string = "unauthenticated-token"
@@ -78,10 +68,8 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloak client: %s", err)
-						os.Exit(1)
+						return fmt.Errorf("got error when invoking Keycloak client: %w", err)
 					}
-					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
 				}
 
 				// Set Auth token.
@@ -100,8 +88,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 			} else {
 				// Create client from config file and using the current or provided context.
 				if localConfig == nil {
-					fmt.Println("Please login to perform operation...")
-					return
+					return fmt.Errorf("please login to perform operation")
 				}
 
 				if globalClientOpts.Context == "" {
@@ -110,8 +97,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
-					fmt.Printf("error %v", err)
-					return
+					return fmt.Errorf("error creating client: %w", err)
 				}
 			}
 
@@ -134,8 +120,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				// Try uploading this artifact.
 				msg, err := mc.UploadArtifact(f, mainArtifact)
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client importing Artifact: %s", err)
-					os.Exit(1)
+					return fmt.Errorf("got error when invoking Microcks client importing Artifact: %w", err)
 				}
 				action := "discovered"
 				if !mainArtifact {
@@ -183,6 +168,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				fmt.Println("Watch mode enabled - microcks-watcher started...")
 				wm.Run()
 			}
+			return nil
 		},
 	}
 

--- a/cmd/importDir.go
+++ b/cmd/importDir.go
@@ -115,13 +115,8 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			microcks import-dir ./api-specs --recursive
 			microcks import-dir ./api-specs --pattern "*.yaml"
 			microcks import-dir ./api-specs --recursive --pattern "openapi.*"`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 {
-				fmt.Println("import-dir command requires a directory path")
-				cmd.HelpFunc()(cmd, args)
-				os.Exit(1)
-			}
-
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
 			dirPath := args[0]
 
 			config.InsecureTLS = globalClientOpts.InsecureTLS
@@ -130,13 +125,11 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			if localConfig == nil {
-				fmt.Println("Please login to perform operation...")
-				return
+				return fmt.Errorf("please login to perform operation")
 			}
 
 			if globalClientOpts.Context == "" {
@@ -146,8 +139,7 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			// Create client
 			mc, err := connectors.NewClient(*globalClientOpts)
 			if err != nil {
-				fmt.Printf("error %v", err)
-				return
+				return fmt.Errorf("error creating client: %w", err)
 			}
 
 			// Set up business logic dependencies
@@ -161,12 +153,7 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			// Execute business logic
 			result, err := ImportDirectory(mc, fs, dirPath, importConfig)
 			if err != nil {
-				if validationErr, ok := err.(*ValidationError); ok {
-					fmt.Println(validationErr.Message)
-					return
-				}
-				fmt.Printf("Error: %v\n", err)
-				os.Exit(1)
+				return err
 			}
 
 			// Display results
@@ -197,6 +184,7 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			}
 
 			fmt.Printf("\nImport completed: %d/%d files imported successfully\n", result.SuccessCount, result.TotalFiles)
+			return nil
 		},
 	}
 

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -32,13 +31,8 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 		Use:   "import-url",
 		Short: "import API artifacts from URL on Microcks server",
 		Long:  `import API artifacts from URL on Microcks server`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// Parse subcommand args first.
-			if len(args) == 0 {
-				fmt.Println("import-url command require <specificationFile1URL[:primary],specificationFile2URL[:primary]> args")
-				os.Exit(1)
-			}
-
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
 			specificationFiles := args[0]
 
 			config.InsecureTLS = globalClientOpts.InsecureTLS
@@ -48,41 +42,32 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			var mc connectors.MicrocksClient
 
 			if globalClientOpts.ServerAddr != "" && globalClientOpts.ClientId != "" && globalClientOpts.ClientSecret != "" {
-				// create client with server address
 				mc = connectors.NewMicrocksClient(globalClientOpts.ServerAddr)
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
-					os.Exit(1)
+					return fmt.Errorf("got error when invoking Microcks client retrieving config: %w", err)
 				}
 
 				var oauthToken string = "unauthenticated-token"
 				if keycloakURL != "null" {
-					// If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
 					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret)
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloak client: %s", err)
-						os.Exit(1)
+						return fmt.Errorf("got error when invoking Keycloak client: %w", err)
 					}
-					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
 				}
 
-				//Set Auth token
 				mc.SetOAuthToken(oauthToken)
 			} else {
-
 				localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 				if err != nil {
-					fmt.Println(err)
-					return
+					return err
 				}
 
 				if localConfig == nil {
-					fmt.Println("Please login to perform operation...")
-					return
+					return fmt.Errorf("please login to perform operation")
 				}
 
 				if globalClientOpts.Context == "" {
@@ -91,16 +76,15 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
-					fmt.Printf("error %v", err)
-					return
+					return fmt.Errorf("error creating client: %w", err)
 				}
 			}
+
 			sepSpecificationFiles := strings.Split(specificationFiles, ",")
 			for _, f := range sepSpecificationFiles {
 				mainArtifact := true
 				secret := ""
 
-				// Check if URL starts with https or http
 				if strings.HasPrefix(f, "https://") || strings.HasPrefix(f, "http://") {
 					urlAndMainAtrifactAndSecretName := strings.Split(f, ":")
 					n := len(urlAndMainAtrifactAndSecretName)
@@ -117,14 +101,13 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 					}
 				}
 
-				// Try downloading the artifcat
 				msg, err := mc.DownloadArtifact(f, mainArtifact, secret)
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client importing Artifact: %s", err)
-					os.Exit(1)
+					return fmt.Errorf("got error when invoking Microcks client importing Artifact: %w", err)
 				}
 				fmt.Printf("Microcks has discovered '%s'\n", msg)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
@@ -28,12 +27,11 @@ microcks start
 microcks start --port [Port you want]
 
 # Define your driver (by default docker)
-microcks start --driver [driver you wnat either 'docker' or 'podman']
+microcks start --driver [driver you want either 'docker' or 'podman']
 
 # Define name of your microcks container/instance
-microcks start --name [name of you container/instance]`,
-		Run: func(cmd *cobra.Command, args []string) {
-
+microcks start --name [name of your container/instance]`,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			configFile := globalClientOpts.ConfigPath
 			localConfig, err := config.ReadLocalConfig(configFile)
 			errors.CheckError(err)
@@ -47,23 +45,17 @@ microcks start --name [name of you container/instance]`,
 				instance = &config.Instance{}
 			}
 
-			if instance.Status == "Running" {
-				fmt.Printf("Microcks instance with name %s is already running", name)
-				return
-			}
-
 			switch instance.Status {
 			case "Running":
-				fmt.Printf("Microcks instance with name %s is already running", name)
-				return
+				fmt.Printf("Microcks instance with name %s is already running\n", name)
+				return nil
 			case "Exited":
 				containerClient, err := connectors.NewContainerClient(instance.Driver)
 				errors.CheckError(err)
 				defer containerClient.CloseClient()
 
 				if err := containerClient.StartContainer(instance.ContainerID); err != nil {
-					log.Fatalf("failed to start container: %v", err)
-					return
+					return fmt.Errorf("failed to start container: %w", err)
 				}
 				instance.Status = "Running"
 			default:
@@ -78,13 +70,11 @@ microcks start --name [name of you container/instance]`,
 					AutoRemove: autoRemove,
 				})
 				if err != nil {
-					log.Fatalf("Failed to create a container: %v", err)
-					return
+					return fmt.Errorf("failed to create container: %w", err)
 				}
 
 				if err := containerClient.StartContainer(containerId); err != nil {
-					log.Fatalf("failed to start container: %v", err)
-					return
+					return fmt.Errorf("failed to start container: %w", err)
 				}
 
 				instance.ContainerID = containerId
@@ -96,7 +86,6 @@ microcks start --name [name of you container/instance]`,
 				instance.Driver = driver
 			}
 
-			//Store config and change context
 			localConfig.UpsertInstance(config.Instance{
 				ContainerID: instance.ContainerID,
 				Name:        instance.Name,
@@ -136,17 +125,18 @@ microcks start --name [name of you container/instance]`,
 				Instance: instance.Name,
 			})
 
-			// Save configs to config file
-			err = config.WriteLocalConfig(*localConfig, configFile)
-			errors.CheckError(err)
+			if err := config.WriteLocalConfig(*localConfig, configFile); err != nil {
+				return fmt.Errorf("failed to write config: %w", err)
+			}
 
 			fmt.Printf("Microcks started successfully at %s\n", server)
+			return nil
 		},
 	}
-	startCmd.Flags().StringVar(&name, "name", "microcks", "name for you microcks instance")
-	startCmd.Flags().StringVar(&hostPort, "port", "8585", "")
+	startCmd.Flags().StringVar(&name, "name", "microcks", "name for your microcks instance")
+	startCmd.Flags().StringVar(&hostPort, "port", "8585", "port to expose Microcks on")
 	startCmd.Flags().StringVar(&imageName, "image", "quay.io/microcks/microcks-uber:latest-native", "image which will be used to create a container")
-	startCmd.Flags().BoolVar(&autoRemove, "rm", false, "mimic of '--rm' flag of dokcer to automatically remove the container when it exits")
-	startCmd.Flags().StringVar(&driver, "driver", "docker", "use --driver to change driver from docker to podman")
+	startCmd.Flags().BoolVar(&autoRemove, "rm", false, "automatically remove the container when it exits")
+	startCmd.Flags().StringVar(&driver, "driver", "docker", "container driver to use: 'docker' or 'podman'")
 	return startCmd
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
@@ -16,15 +15,14 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 		Use:   "stop",
 		Short: "stop microcks instance",
 		Long:  "stop microcks instance",
-		Run: func(cmd *cobra.Command, args []string) {
-
+		RunE: func(cmd *cobra.Command, args []string) error {
 			configFile := globalClientOpts.ConfigPath
 			localConfig, err := config.ReadLocalConfig(configFile)
 			errors.CheckError(err)
 
 			if localConfig == nil {
 				fmt.Println("Config not found, nothing to stop")
-				return
+				return nil
 			}
 
 			ctx, err := localConfig.ResolveContext("")
@@ -32,29 +30,23 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			instance := ctx.Instance
 
 			if instance.Name == "" {
-				fmt.Println("No instance is associated with this context")
-				return
+				return fmt.Errorf("no instance is associated with this context")
 			}
 
 			containerClient, err := connectors.NewContainerClient(instance.Driver)
 			errors.CheckError(err)
 			defer containerClient.CloseClient()
 
-			err = containerClient.StopContainer(instance.ContainerID)
-			if err != nil {
-				log.Fatalf("Failed to stop a container: %v", err)
-				return
+			if err := containerClient.StopContainer(instance.ContainerID); err != nil {
+				return fmt.Errorf("failed to stop container: %w", err)
 			}
-			fmt.Println("")
-			log.Printf("Instance %s stopped successfully", instance.Name)
 
-			// update configs
+			fmt.Printf("Instance %s stopped successfully\n", instance.Name)
 
 			if instance.AutoRemove {
 				_, ok := localConfig.RemoveContext(ctx.Name)
 				if !ok {
-					log.Fatalf("Context %s does not exist", ctx.Name)
-					return
+					return fmt.Errorf("context %s does not exist", ctx.Name)
 				}
 				_ = localConfig.RemoveServer(ctx.Server.Server)
 				_ = localConfig.RemoveUser(ctx.User.Name)
@@ -62,14 +54,17 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				_ = localConfig.RemoveInstance(instance.Name)
 
 				localConfig.CurrentContext = ""
-				log.Printf("Instance %s removed successfully", instance.Name)
+				fmt.Printf("Instance %s removed successfully\n", instance.Name)
 			} else {
 				instance.Status = "Exited"
 				localConfig.UpsertInstance(instance)
-				log.Printf("Instance %s status updated to Exited", instance.Name)
+				fmt.Printf("Instance %s status updated to Exited\n", instance.Name)
 			}
-			err = config.WriteLocalConfig(*localConfig, configFile)
-			errors.CheckError(err)
+
+			if err := config.WriteLocalConfig(*localConfig, configFile); err != nil {
+				return fmt.Errorf("failed to write config: %w", err)
+			}
+			return nil
 		},
 	}
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -27,6 +26,32 @@ import (
 	"github.com/microcks/microcks-cli/pkg/errors"
 	"github.com/spf13/cobra"
 )
+
+// parseWaitForMilliseconds converts a waitFor string (e.g. "5sec", "500milli", "2min") to milliseconds.
+func parseWaitForMilliseconds(waitFor string) (int64, error) {
+	switch {
+	case strings.HasSuffix(waitFor, "milli"):
+		n, err := strconv.ParseInt(waitFor[:len(waitFor)-5], 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("--waitFor value %q is not a valid number", waitFor)
+		}
+		return n, nil
+	case strings.HasSuffix(waitFor, "sec"):
+		n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("--waitFor value %q is not a valid number", waitFor)
+		}
+		return n * 1000, nil
+	case strings.HasSuffix(waitFor, "min"):
+		n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("--waitFor value %q is not a valid number", waitFor)
+		}
+		return n * 60 * 1000, nil
+	default:
+		return 0, fmt.Errorf("--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)")
+	}
+}
 
 var (
 	runnerChoices = map[string]bool{"HTTP": true, "SOAP_HTTP": true, "SOAP_UI": true, "POSTMAN": true, "OPEN_API_SCHEMA": true, "ASYNC_API_SCHEMA": true, "GRPC_PROTOBUF": true, "GRAPHQL_SCHEMA": true}
@@ -41,44 +66,24 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 		oAuth2Context      string
 	)
 	var testCmd = &cobra.Command{
-
 		Use:   "test",
 		Short: "Run tests on Microcks",
 		Long:  `Run tests on Microcks`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// Parse subcommand args first.
-			if len(os.Args) < 4 {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
-				os.Exit(1)
+		Args:  cobra.ExactArgs(3),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			runnerType := args[2]
+			if _, valid := runnerChoices[runnerType]; !valid {
+				return fmt.Errorf("<runner> must be one of: HTTP, SOAP_HTTP, SOAP_UI, POSTMAN, OPEN_API_SCHEMA, ASYNC_API_SCHEMA, GRPC_PROTOBUF, GRAPHQL_SCHEMA")
 			}
-
+if !strings.HasSuffix(waitFor, "milli") && !strings.HasSuffix(waitFor, "sec") && !strings.HasSuffix(waitFor, "min") {
+				return fmt.Errorf("--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			serviceRef := args[0]
 			testEndpoint := args[1]
 			runnerType := args[2]
-
-			// Validate presence and values of args.
-			if len(serviceRef) == 0 || strings.HasPrefix(serviceRef, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
-				os.Exit(1)
-			}
-			if len(testEndpoint) == 0 || strings.HasPrefix(testEndpoint, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
-				os.Exit(1)
-			}
-			if len(runnerType) == 0 || strings.HasPrefix(runnerType, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
-				os.Exit(1)
-			}
-			if _, validChoice := runnerChoices[runnerType]; !validChoice {
-				fmt.Println("<runner> should be one of: HTTP, SOAP, SOAP_UI, POSTMAN, OPEN_API_SCHEMA, ASYNC_API_SCHEMA, GRPC_PROTOBUF, GRAPHQL_SCHEMA")
-				os.Exit(1)
-			}
-
-			// Validate presence and values of flags.
-			if !strings.HasSuffix(waitFor, "milli") && !strings.HasSuffix(waitFor, "sec") && !strings.HasSuffix(waitFor, "min") {
-				fmt.Println("--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)")
-				os.Exit(1)
-			}
 
 			// Collect optional HTTPS transport flags.
 			config.InsecureTLS = globalClientOpts.InsecureTLS
@@ -86,28 +91,9 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			config.Verbose = globalClientOpts.Verbose
 
 			// Compute time to wait in milliseconds.
-			var waitForMilliseconds int64
-			if strings.HasSuffix(waitFor, "milli") {
-				n, err := strconv.ParseInt(waitFor[:len(waitFor)-5], 0, 64)
-				if err != nil {
-					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
-					os.Exit(1)
-				}
-				waitForMilliseconds = n
-			} else if strings.HasSuffix(waitFor, "sec") {
-				n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
-				if err != nil {
-					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
-					os.Exit(1)
-				}
-				waitForMilliseconds = n * 1000
-			} else if strings.HasSuffix(waitFor, "min") {
-				n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
-				if err != nil {
-					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
-					os.Exit(1)
-				}
-				waitForMilliseconds = n * 60 * 1000
+			waitForMilliseconds, err := parseWaitForMilliseconds(waitFor)
+			if err != nil {
+				return err
 			}
 
 			var mc connectors.MicrocksClient
@@ -121,36 +107,29 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
-					os.Exit(1)
+					return fmt.Errorf("got error when invoking Microcks client retrieving config: %w", err)
 				}
 
 				var oauthToken string = "unauthenticated-token"
 				if keycloakURL != "null" {
-					// If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
 					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret)
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloak client: %s", err)
-						os.Exit(1)
+						return fmt.Errorf("got error when invoking Keycloak client: %w", err)
 					}
-					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
 				}
 
-				// Then - launch the test on Microcks Server.
 				mc.SetOAuthToken(oauthToken)
 
 			} else {
 				localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 				if err != nil {
-					fmt.Println(err)
-					return
+					return err
 				}
 
 				if localConfig == nil {
-					fmt.Println("Please login to perform operation...")
-					return
+					return fmt.Errorf("please login to perform operation")
 				}
 
 				if globalClientOpts.Context == "" {
@@ -159,8 +138,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
-					fmt.Printf("error %v", err)
-					return
+					return fmt.Errorf("error creating client: %w", err)
 				}
 
 				ctx, err := localConfig.ResolveContext(globalClientOpts.Context)
@@ -169,27 +147,22 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				serverAddr = ctx.Server.Server
 			}
 
-			var testResultID string
 			testResultID, err := mc.CreateTestResult(serviceRef, testEndpoint, runnerType, secretName, waitForMilliseconds, filteredOperations, operationsHeaders, oAuth2Context)
 			if err != nil {
-				fmt.Printf("Got error when invoking Microcks client creating Test: %s", err)
-				os.Exit(1)
+				return fmt.Errorf("got error when invoking Microcks client creating Test: %w", err)
 			}
-			//fmt.Printf("Retrieve TestResult ID: %s", testResultID)
 
-			// Finally - wait before checking and loop for some time
+			// Wait before polling.
 			time.Sleep(1 * time.Second)
 
 			// Add 10.000ms to wait time as it's now representing the server timeout.
-			now := nowInMilliseconds()
-			future := now + waitForMilliseconds + 10000
+			future := nowInMilliseconds() + waitForMilliseconds + 10000
 
 			var success = false
 			for nowInMilliseconds() < future {
 				testResultSummary, err := mc.GetTestResult(testResultID)
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client check TestResult: %s", err)
-					os.Exit(1)
+					return fmt.Errorf("got error when invoking Microcks client check TestResult: %w", err)
 				}
 				success = testResultSummary.Success
 				inProgress := testResultSummary.InProgress
@@ -206,8 +179,9 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			fmt.Printf("Full TestResult details are available here: %s/#/tests/%s \n", serverAddr, testResultID)
 
 			if !success {
-				os.Exit(1)
+				return fmt.Errorf("test \"%s\" failed", testResultID)
 			}
+			return nil
 		},
 	}
 


### PR DESCRIPTION
1) add `SilenceErrors: true` to root command to prevent errors being printed twice by both Cobra and `main()`.
2)   `import`, `import-url`, `import-dir`: `cobra.ExactArgs(1)` replaces manual `len(args)` guard and `os.Exit`; `RunE` returns wrapped errors.
3)  `test`: `cobra.ExactArgs(3)` replaces direct `os.Args` inspection; `PreRunE` validates `--waitFor` format and runner type before any network call; extract `parseWaitForMilliseconds` helper for testability
4)   `start`, `stop`: `RunE` replaces `log.Fatalf` with `fmt.Errorf`
5) all subcommands now return errors instead of calling `os.Exit` — errors propagate cleanly to `main()`.

Fixes #281
