### PR TITLE
fix(test): list SOAP_HTTP in runner error message

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -70,7 +70,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				os.Exit(1)
 			}
 			if _, validChoice := runnerChoices[runnerType]; !validChoice {
-				fmt.Println("<runner> should be one of: HTTP, SOAP, SOAP_UI, POSTMAN, OPEN_API_SCHEMA, ASYNC_API_SCHEMA, GRPC_PROTOBUF, GRAPHQL_SCHEMA")
+				fmt.Println("<runner> should be one of: HTTP, SOAP_HTTP, SOAP_UI, POSTMAN, OPEN_API_SCHEMA, ASYNC_API_SCHEMA, GRPC_PROTOBUF, GRAPHQL_SCHEMA")
 				os.Exit(1)
 			}
 


### PR DESCRIPTION
## Summary

This PR fixes the invalid runner error message in `microcks test`.

The command validates `SOAP_HTTP` as the SOAP HTTP runner, but the invalid runner error message listed `SOAP`. This could mislead users into trying a runner value that is not accepted.

This PR updates the error message to list `SOAP_HTTP`, matching the actual valid runner values.

No runner validation behavior is changed.

Fixes #348 

## Test plan

- [x] `go run . test foo:1 http://x SOAP`
- [x] `go run . test foo:1 http://x BOGUS`
- [x] `make build-local`