### PR TITLE
fix(import): preserve paths containing colons when parsing primary su…

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -118,18 +118,10 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 			// Handle multiple specification files separated by comma.
 			sepSpecificationFiles := strings.Split(specificationFiles, ",")
 			for _, f := range sepSpecificationFiles {
-				mainArtifact := true
-				var err error
-
-				// Check if mainArtifact flag is provided.
-				if strings.Contains(f, ":") {
-					pathAndMainArtifact := strings.Split(f, ":")
-					f = pathAndMainArtifact[0]
-					mainArtifact, err = strconv.ParseBool(pathAndMainArtifact[1])
-					if err != nil {
-						fmt.Printf("Cannot parse '%s' as Bool, default to true\n", pathAndMainArtifact[1])
-					}
-				}
+				// Parse optional :true / :false suffix. Preserves paths
+				// containing colons (e.g. Windows C:\Temp\api.yaml).
+				path, mainArtifact := parseImportEntry(f)
+				f = path
 
 				// Try uploading this artifact.
 				msg, err := mc.UploadArtifact(f, mainArtifact)
@@ -188,4 +180,26 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 	importCmd.Flags().BoolVar(&watch, "watch", false, "Keep watch on file changes and re-import it on change")
 	return importCmd
+}
+
+// parseImportEntry parses a single comma-separated entry of the import
+// command argument. The accepted forms are "<path>" and
+// "<path>:<bool>", where <bool> is anything strconv.ParseBool accepts
+// (true, false, TRUE, FALSE, 1, 0, t, f, ...). Because <path> may
+// itself contain colons (e.g. Windows-absolute paths such as
+// C:\Temp\api.yaml), the optional boolean suffix is detected from the
+// right: only the substring after the last ':' is considered, and
+// only when it parses as a bool is it treated as the mainArtifact
+// flag. Otherwise the whole input is returned unchanged with
+// mainArtifact defaulting to true.
+func parseImportEntry(input string) (string, bool) {
+	idx := strings.LastIndex(input, ":")
+	if idx < 0 {
+		return input, true
+	}
+	b, err := strconv.ParseBool(input[idx+1:])
+	if err != nil {
+		return input, true
+	}
+	return input[:idx], b
 }

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseImportEntry(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            string
+		wantPath         string
+		wantMainArtifact bool
+	}{
+		{"relative path, no suffix", "./api.yaml", "./api.yaml", true},
+		{"relative path, :true suffix", "./api.yaml:true", "./api.yaml", true},
+		{"relative path, :false suffix", "./api.yaml:false", "./api.yaml", false},
+		{"relative path, :TRUE suffix (ParseBool)", "./api.yaml:TRUE", "./api.yaml", true},
+		{"relative path, :0 suffix (ParseBool)", "./api.yaml:0", "./api.yaml", false},
+		{"Windows absolute path, no suffix", `C:\Temp\api.yaml`, `C:\Temp\api.yaml`, true},
+		{"Windows absolute path, :false suffix", `C:\Temp\api.yaml:false`, `C:\Temp\api.yaml`, false},
+		{"Windows absolute path, :true suffix", `C:\Temp\api.yaml:true`, `C:\Temp\api.yaml`, true},
+		{"path with multiple colons, no bool suffix", "path:with:colon.yaml", "path:with:colon.yaml", true},
+		{"path with multiple colons, :false suffix", "path:with:colon.yaml:false", "path:with:colon.yaml", false},
+		{"non-bool trailing segment is part of path", "./api.yaml:notabool", "./api.yaml:notabool", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotMain := parseImportEntry(tt.input)
+			assert.Equal(t, tt.wantPath, gotPath, "path")
+			assert.Equal(t, tt.wantMainArtifact, gotMain, "mainArtifact")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`microcks import` previously parsed the optional `:true` / `:false` suffix with `strings.Split(input, ":")[0]`, which splits on the **first** colon. Any input containing more than one colon — including Windows-absolute paths such as `C:\Temp\api.yaml` — had its path truncated to the part before the first colon, and the rest was passed to `strconv.ParseBool`. The eventual upload failed with `open C: no such file or directory`, with no hint that the parser had silently eaten the path.

This PR fixes the parser to detect the boolean suffix from the **right** using `strings.LastIndex` + `strconv.ParseBool`, so paths containing colons (Windows-absolute paths, paths with multiple colons) are preserved while the documented `:true` / `:false` suffix continues to work exactly as before.

---

## Why

- Windows users are blocked from using absolute paths with `microcks import` today.
- The failure mode (`open C: no such file or directory`) gives no hint that the parser truncated the path.
- All currently-documented inputs (`./api.yaml`, `./api.yaml:true`, `./api.yaml:false`, `./api.yaml:1`, …) keep working identically after the fix — this is a strict superset of previous behavior.

---

## What changed

- Extracted a small pure helper `parseImportEntry(input string) (string, bool)` in `cmd/import.go`.
- The helper inspects the substring after the **last** `:` and only treats it as `mainArtifact` when `strconv.ParseBool` succeeds; otherwise the entire input is treated as the path with `mainArtifact = true`.
- Replaced the inline `if strings.Contains(f, ":") { ... }` block in the import loop with a single call to the helper.
- Removed the now-redundant `Cannot parse '...' as Bool` warning, because the new logic treats a non-bool trailing segment as part of the path rather than a parse failure.
- Added a new test file `cmd/import_test.go` with table-driven cases for the parser.

---

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l cmd/import.go cmd/import_test.go` — no output
- [x] `go test ./cmd/... -run TestParseImportEntry -v` — all table rows pass
- [x] `go test ./...` — full sweep passes
- [x] `go test ./cmd/... -count=3` — passes (no state leakage)
- [x] Manually verified on Windows: `microcks import C:\Temp\api.yaml` no longer fails with `open C: no such file or directory`
- [x] Manually verified that `./api.yaml`, `./api.yaml:true`, `./api.yaml:false`, `./api.yaml:1` all parse as before

---

## Test cases covered

The table-driven test exercises:

| Input | Path | mainArtifact |
| --- | --- | --- |
| `./api.yaml` | `./api.yaml` | `true` |
| `./api.yaml:true` | `./api.yaml` | `true` |
| `./api.yaml:false` | `./api.yaml` | `false` |
| `./api.yaml:TRUE` | `./api.yaml` | `true` |
| `./api.yaml:0` | `./api.yaml` | `false` |
| `C:\Temp\api.yaml` | `C:\Temp\api.yaml` | `true` |
| `C:\Temp\api.yaml:false` | `C:\Temp\api.yaml` | `false` |
| `C:\Temp\api.yaml:true` | `C:\Temp\api.yaml` | `true` |
| `path:with:colon.yaml` | `path:with:colon.yaml` | `true` |
| `path:with:colon.yaml:false` | `path:with:colon.yaml` | `false` |
| `./api.yaml:notabool` | `./api.yaml:notabool` | `true` |

---

## Files changed

- `cmd/import.go` — parser refactored; `strconv` import retained for `ParseBool`.
- `cmd/import_test.go` — new file; first test in this package's import-command path.

---

## Notes

- No flag changes; no behavior change for currently-working inputs.
- A similar bug exists in `cmd/importURL.go` for URLs that include a port (e.g. `https://localhost:8080/api.yaml`). It is intentionally left out of this PR to keep scope tight; happy to send a follow-up if maintainers prefer that shape.
- This is one of my early contributions to the repo; I am still learning Go and welcome any feedback on idiom or structure.

Closes #352
