### PR TITLE
feat: new `-distroless` variant based on the new DHI image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+registries:
+  dhi:
+    type: docker-registry
+    url: dhi.io
+    username: ${{ secrets.DOCKERHUB_USERNAME }}
+    password: ${{ secrets.DOCKERHUB_TOKEN }}
 updates:
   - package-ecosystem: github-actions
     directory: /
@@ -19,5 +25,7 @@ updates:
     schedule:
       interval: monthly
       day: sunday
+    registries:
+    - dhi
     open-pull-requests-limit: 3
     rebase-strategy: disabled

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -113,3 +113,33 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign --new-bundle-format=false --use-signing-config=false --yes ${images}
+      
+      - name: Build and push container image for cli as distroless
+        id: build-and-push-distroless
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        if: github.repository_owner == 'microcks' && env.PACKAGE_IMAGE == 'true'
+        with:
+          context: .
+          sbom: true
+          push: true
+          provenance: mode=max
+          platforms: linux/amd64,linux/arm64
+          builder: buildx-multi-arch
+          file: build/Dockerfile.dhi
+          labels: |
+            org.opencontainers.image.revision=${GITHUB_SHA}
+            org.opencontainers.image.created=${{ steps.date.outputs.date }}
+          tags: quay.io/microcks/microcks-cli:${{env.IMAGE_TAG}}-distroless,docker.io/microcks/microcks-cli:${{env.IMAGE_TAG}}-distroless
+
+      - name: Sign the distroless image with GitHub OIDC Token
+        if: github.repository_owner == 'microcks' && env.PACKAGE_IMAGE == 'true'
+        env:
+          DIGEST: ${{ steps.build-and-push-distroless.outputs.digest }}
+          TAGS: quay.io/microcks/microcks-cli:${{env.IMAGE_TAG}}-distroless docker.io/microcks/microcks-cli:${{env.IMAGE_TAG}}-distroless
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --new-bundle-format=false --use-signing-config=false --yes ${images}

--- a/build/Dockerfile.dhi
+++ b/build/Dockerfile.dhi
@@ -1,0 +1,25 @@
+# Build binary
+FROM --platform=$BUILDPLATFORM dhi.io/golang:1.25.9-alpine3.23-dev AS build-env
+ADD . /app
+WORKDIR /app
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags="-s -w" -o microcks github.com/microcks/microcks-cli
+    
+# Build image
+FROM dhi.io/static:20260413-alpine3.23
+
+# Some version information
+LABEL maintainer="Laurent Broudoux <laurent@microcks.io>" \
+      org.opencontainers.image.authors="Laurent Broudoux <laurent@microcks.io>" \
+      org.opencontainers.image.title="Microcks CLI" \
+      org.opencontainers.image.description="Microcks is Open Source cloud-native native tool for API Mocking and Testing" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.documentation="https://github.com/microcks/microcks-cli" \
+      io.artifacthub.package.readme-url="https://raw.githubusercontent.com/microcks/microcks-cli/master/README.md"
+
+# install cli binary
+COPY --from=build-env /app/microcks /usr/local/bin/microcks
+
+COPY build/bin /usr/local/bin


### PR DESCRIPTION
New `-distroless` variant (based on DHI images), implementation for https://github.com/microcks/microcks-cli/issues/298.

tl,dr - With DHI it's:
- 132 packages less
- 150MB on disk less
- 22 CVEs less
- `distroless` (no unnecessary package manager, `bash`, `curl`, etc.)

Notes:
- `USER` is changing from `1001` to `65532` (still non-root user)
- `alpine` was chosen here, just for your information `debian` flavor exists. `alpine` allows to get a smaller footprint, especially for this CLI component.
- `dhi.io/golang:1.25.10` already exists and could fix more CVEs, but want to keep this PR with `1.25.9` for now to compare apples and apples between the before and after. Once this one is merged, Dependabot will anyway bump `1.25.9` to `1.25.10`.

Tested these successfully:
```bash
docker run --rm -it microcks-cli:dhi microcks version

docker run --rm -it microcks-cli:dhi microcks help
```
Important: I encourage the reviewers to conduct more tests with this new container image.

This is saving ~150MB on disk locally:
```none
IMAGE                 ID             DISK USAGE   CONTENT SIZE   EXTRA
microcks-cli:before   3d1e2800001a        164MB         43.7MB        
microcks-cli:dhi      4ebd097b354e       14.8MB         3.92MB
```

Summary of the diff by running `docker scout compare --to microcks-cli:before microcks-cli:dhi`:
<img width="2256" height="530" alt="image" src="https://github.com/user-attachments/assets/00023a79-7eaa-4904-811e-04e0da4745de" />

Here below are all the details showing the diffs between before and after.

## Environment Variables

```diff
- CLI=/usr/local/bin/microcks
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
- USER_NAME=microcks-cli
- USER_UID=1001
- container=oci
``` 

## Labels

```diff
- architecture=x86_64
- build-date=2026-04-22T04:58:33Z
+ com.docker.dhi.chain-id=sha256:343f0268d44d4da868554a86fec4da098d055aa05c6a4b0316508ad9a8c98dd3
+ com.docker.dhi.compliance=cis
+ com.docker.dhi.created=2026-04-15T17:06:34Z
+ com.docker.dhi.definition=image/static/alpine-3.23/static
+ com.docker.dhi.distro=alpine-3.23
+ com.docker.dhi.entitlement=public
+ com.docker.dhi.flavor=
+ com.docker.dhi.name=dhi/static
+ com.docker.dhi.package-manager=
+ com.docker.dhi.shell=
+ com.docker.dhi.title=Static (Alpine)
+ com.docker.dhi.url=https://dhi.io/catalog/static
+ com.docker.dhi.variant=runtime
+ com.docker.dhi.version=20260413-alpine3.23
- com.redhat.component=ubi9-minimal-container
- com.redhat.license_terms=https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI
- cpe=cpe:/a:redhat:enterprise_linux:9::appstream
- description=The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.
- distribution-scope=public
io.artifacthub.package.readme-url=https://raw.githubusercontent.com/microcks/microcks-cli/master/README.md
- io.buildah.version=1.42.2
- io.k8s.description=The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.
- io.k8s.display-name=Red Hat Universal Base Image 9 Minimal
- io.openshift.expose-services=
- io.openshift.tags=minimal rhel9
maintainer=Laurent Broudoux <laurent@microcks.io>
- name=ubi9/ubi-minimal
org.opencontainers.image.authors=Laurent Broudoux <laurent@microcks.io>
- org.opencontainers.image.created=2026-04-22T04:58:33Z
org.opencontainers.image.description=Microcks is Open Source cloud-native native tool for API Mocking and Testing
org.opencontainers.image.documentation=https://github.com/microcks/microcks-cli
org.opencontainers.image.licenses=Apache-2.0
- org.opencontainers.image.revision=5bb1e5f6eb0dd42dce5d2f21f64a3a9feec995f1
org.opencontainers.image.title=Microcks CLI
- release=1776833838
- summary=Provides the latest release of the minimal Red Hat Universal Base Image 9.
- url=https://catalog.redhat.com/en/search?searchType=containers
- vcs-ref=5bb1e5f6eb0dd42dce5d2f21f64a3a9feec995f1
- vcs-type=git
- vendor=Red Hat, Inc.
- version=9.7
``` 

## Config

```diff
- cmd=/bin/bash
+ cmd=
- user=1001
+ user=65532
workdir=/
```

## Packages and Vulnerabilities

- 6 packages added
- 137 packages removed
- 31 packages unchanged
- 25 vulnerabilities removed

```diff
-  acl                               rpm                                        2.3.1-4.el9
+  alpine-baselayout                 apk     3.7.2-r0
+  alpine-baselayout-data            apk     3.7.2-r0
-  alternatives                      rpm                                        1.24-2.el9
-  attr                              rpm                                        2.5.1-3.el9
-  audit                             rpm                                        3.1.5-7.el9
-  audit-libs                        rpm                                        3.1.5-7.el9
-  basesystem                        rpm                                        11-13.el9
-  bash                              rpm                                        5.1.8-9.el9
-  bzip2                             rpm                                        1.0.8-10.el9_5
-  bzip2-libs                        rpm                                        1.0.8-10.el9_5
+  ca-certificates                   apk     20260413-r0
-  ca-certificates                   rpm                                        2024.2.69_v8.0.303-91.4.el9_4
+  ca-certificates-bundle            apk     20260413-r0
-  chkconfig                         rpm                                        1.24-2.el9
-  coreutils                         rpm                                        8.32-39.el9
-  coreutils-single                  rpm                                        8.32-39.el9
-  crypto-policies                   rpm                                        20250905-1.git377cc42.el9_7
-  curl                              rpm                                        7.76.1-35.el9_7.3
-   └─  -  MEDIUM       CVE-2025-9086   [https://scout.docker.com/v/CVE-2025-9086] 5.3  Out-of-bounds Read
-  curl-minimal                      rpm                                        7.76.1-35.el9_7.3
-  cyrus-sasl                        rpm                                        2.1.27-22.el9
-  cyrus-sasl-lib                    rpm                                        2.1.27-22.el9
-  dejavu-fonts                      rpm                                        2.37-18.el9
-  dejavu-sans-fonts                 rpm                                        2.37-18.el9
-  dnf                               rpm                                        4.14.0-31.el9
-  dnf-data                          rpm                                        4.14.0-31.el9
-  e2fsprogs                         rpm                                        1.46.5-8.el9
-  file                              rpm                                        5.39-16.el9
-  file-libs                         rpm                                        5.39-16.el9
-  filesystem                        rpm                                        3.16-5.el9
-  fonts-filesystem                  rpm                                        1:2.0.5-7.el9.1
-  fonts-rpm-macros                  rpm                                        1:2.0.5-7.el9.1
-  gawk                              rpm                                        5.1.0-6.el9
-  gcc                               rpm                                        11.5.0-11.el9
-  gdbm                              rpm                                        1:1.23-1.el9
-  gdbm-libs                         rpm                                        1:1.23-1.el9
-  glib2                             rpm                                        2.68.4-18.el9_7.1
-   ├─  -  MEDIUM       CVE-2025-13601  [https://scout.docker.com/v/CVE-2025-13601] 7.7  Integer Overflow or Wraparound
-   └─  -  LOW          CVE-2025-7039   [https://scout.docker.com/v/CVE-2025-7039] 3.7
-  glibc                             rpm                                        2.34-231.el9_7.10
-   ├─  -  HIGH         CVE-2026-0861   [https://scout.docker.com/v/CVE-2026-0861] 9.8  Integer Overflow or Wraparound
-   ├─  -  HIGH         CVE-2026-4046   [https://scout.docker.com/v/CVE-2026-4046] 7.5  Reachable Assertion
-   ├─  -  MEDIUM       CVE-2026-0915   [https://scout.docker.com/v/CVE-2026-0915] 5.3  Use of Uninitialized Resource
-   └─  -  LOW          CVE-2025-15281  [https://scout.docker.com/v/CVE-2025-15281] 5.9  Use of Uninitialized Resource
-  glibc-common                      rpm                                        2.34-231.el9_7.10
-  glibc-minimal-langpack            rpm                                        2.34-231.el9_7.10
-  gmp                               rpm                                        1:6.2.0-13.el9
-  gnupg2                            rpm                                        2.3.3-5.el9_7
-   ├─  -  HIGH         CVE-2026-24882  [https://scout.docker.com/v/CVE-2026-24882] 8.4  Stack-based Buffer Overflow
-   ├─  -  HIGH         CVE-2026-24881  [https://scout.docker.com/v/CVE-2026-24881] 8.1  Stack-based Buffer Overflow
-   └─  -  HIGH         CVE-2025-68973  [https://scout.docker.com/v/CVE-2025-68973] 7.8  Multiple Operations on Resource in Single-Operation Context
-  gnutls                            rpm                                        3.8.3-10.el9_7
-   ├─  -  HIGH         CVE-2026-33846  [https://scout.docker.com/v/CVE-2026-33846]  7.5  Improper Handling of Length Parameter Inconsistency
-   ├─  -  HIGH         CVE-2026-33845  [https://scout.docker.com/v/CVE-2026-33845] 7.5  Integer Underflow (Wrap or Wraparound)
-   ├─  -  MEDIUM       CVE-2026-3833   [https://scout.docker.com/v/CVE-2026-3833] 6.5  Improper Handling of Case Sensitivity
-   └─  -  MEDIUM       CVE-2025-14831  [https://scout.docker.com/v/CVE-2025-14831] 5.3  Inefficient Algorithmic Complexity
-  gobject-introspection             rpm                                        1.68.0-11.el9
-  gpg-pubkey                        rpm                                        fd431d51-4ae0493b
-  gpgme                             rpm                                        1.15.1-6.el9
-  grep                              rpm                                        3.6-5.el9
-  json-c                            rpm                                        0.14-11.el9
-  json-glib                         rpm                                        1.6.6-1.el9
-  keyutils                          rpm                                        1.6.3-1.el9
-  keyutils-libs                     rpm                                        1.6.3-1.el9
-  krb5                              rpm                                        1.21.1-9.el9_7
-   ├─  -  HIGH         CVE-2026-40356  [https://scout.docker.com/v/CVE-2026-40356] 5.9  Integer Underflow (Wrap or Wraparound)
-   └─  -  MEDIUM       CVE-2026-40355  [https://scout.docker.com/v/CVE-2026-40355] 5.9  NULL Pointer Dereference
-  krb5-libs                         rpm                                        1.21.1-9.el9_7
-  langpacks                         rpm                                        3.0-16.el9
-  langpacks-core-en                 rpm                                        3.0-16.el9
-  langpacks-core-font-en            rpm                                        3.0-16.el9
-  langpacks-en                      rpm                                        3.0-16.el9
-  libacl                            rpm                                        2.3.1-4.el9
-  libarchive                        rpm                                        3.5.3-9.el9_7
-   ├─  -  HIGH         CVE-2026-4424   [https://scout.docker.com/v/CVE-2026-4424] 7.5  Out-of-bounds Read
-   └─  -  MEDIUM       CVE-2026-5121   [https://scout.docker.com/v/CVE-2026-5121] 0.0
-  libassuan                         rpm                                        2.5.5-3.el9
-  libattr                           rpm                                        2.5.1-3.el9
-  libblkid                          rpm                                        2.37.4-21.el9_7
-  libcap                            rpm                                        2.48-10.el9
-  libcap-ng                         rpm                                        0.8.2-7.el9
-  libcom_err                        rpm                                        1.46.5-8.el9
-  libcurl-minimal                   rpm                                        7.76.1-35.el9_7.3
-  libdnf                            rpm                                        0.69.0-17.el9_7
-  libevent                          rpm                                        2.1.12-8.el9_4
-  libffi                            rpm                                        3.4.2-8.el9
-  libgcc                            rpm                                        11.5.0-11.el9
-  libgcrypt                         rpm                                        1.10.0-11.el9
-  libgpg-error                      rpm                                        1.42-5.el9
-  libidn2                           rpm                                        2.3.0-7.el9
-  libksba                           rpm                                        1.5.1-7.el9
-  libmodulemd                       rpm                                        2.13.0-2.el9
-  libmount                          rpm                                        2.37.4-21.el9_7
-  libnghttp2                        rpm                                        1.43.0-6.el9_7.1
-  libpeas                           rpm                                        1.30.0-4.el9
-  librepo                           rpm                                        1.14.5-3.el9
-  libreport                         rpm                                        2.15.2-6.el9
-  libreport-filesystem              rpm                                        2.15.2-6.el9
-  librhsm                           rpm                                        0.0.3-9.el9
-  libselinux                        rpm                                        3.6-3.el9
-  libsemanage                       rpm                                        3.6-5.el9_6
-  libsepol                          rpm                                        3.6-3.el9
-  libsigsegv                        rpm                                        2.13-4.el9
-  libsmartcols                      rpm                                        2.37.4-21.el9_7
-  libsolv                           rpm                                        0.7.24-3.el9
-  libstdc++                         rpm                                        11.5.0-11.el9
-  libtasn1                          rpm                                        4.16.0-9.el9
-   └─  -  MEDIUM       CVE-2025-13151  [https://scout.docker.com/v/CVE-2025-13151] 5.9  Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-  libtool                           rpm                                        2.4.6-46.el9
-  libtool-ltdl                      rpm                                        2.4.6-46.el9
-  libunistring                      rpm                                        0.9.10-15.el9
-  libusbx                           rpm                                        1.0.26-1.el9
-  libuuid                           rpm                                        2.37.4-21.el9_7
-  libverto                          rpm                                        0.3.2-3.el9
-  libxcrypt                         rpm                                        4.4.18-3.el9
-  libxml2                           rpm                                        2.9.13-14.el9_7
-  libyaml                           rpm                                        0.2.5-7.el9
-  libzstd                           rpm                                        1.5.5-1.el9
-  lua                               rpm                                        5.4.4-4.el9
-  lua-libs                          rpm                                        5.4.4-4.el9
-  lz4                               rpm                                        1.9.3-5.el9
-  lz4-libs                          rpm                                        1.9.3-5.el9
-  microdnf                          rpm                                        3.9.1-3.el9
-  mpfr                              rpm                                        4.1.0-7.el9
-  ncurses                           rpm                                        6.2-12.20210508.el9
-  ncurses-base                      rpm                                        6.2-12.20210508.el9
-  ncurses-libs                      rpm                                        6.2-12.20210508.el9
-  nettle                            rpm                                        3.10.1-1.el9
-  nghttp2                           rpm                                        1.43.0-6.el9_7.1
-   └─  -  HIGH         CVE-2026-27135  [https://scout.docker.com/v/CVE-2026-27135] 7.5  Reachable Assertion
-  npth                              rpm                                        1.6-8.el9
-  openldap                          rpm                                        2.6.8-4.el9
-  openssl                           rpm                                        1:3.5.1-7.el9_7
-   ├─  -  MEDIUM       CVE-2026-28390  [https://scout.docker.com/v/CVE-2026-28390] 7.5  NULL Pointer Dereference
-   └─  -  MEDIUM       CVE-2026-31790  [https://scout.docker.com/v/CVE-2026-31790] 5.9  Access of Uninitialized Pointer
-  openssl-fips-provider             rpm                                        3.0.7-8.el9
-  openssl-fips-provider-so          rpm                                        3.0.7-8.el9
-  openssl-libs                      rpm                                        1:3.5.1-7.el9_7
-  p11-kit                           rpm                                        0.25.3-3.el9_5
-  p11-kit-trust                     rpm                                        0.25.3-3.el9_5
-  pcre                              rpm                                        8.44-4.el9
-  pcre2                             rpm                                        10.40-6.el9
-  pcre2-syntax                      rpm                                        10.40-6.el9
-  popt                              rpm                                        1.18-8.el9
-  readline                          rpm                                        8.1-4.el9
-  redhat-release                    rpm                                        9.7-0.7.el9
-  rootfiles                         rpm                                        8.1-35.el9
-  rpm                               rpm                                        4.16.1.3-39.el9
-  rpm-libs                          rpm                                        4.16.1.3-39.el9
-  sed                               rpm                                        4.8-9.el9
-  setup                             rpm                                        2.13.7-10.el9 
-  shadow-utils                      rpm                                        2:4.9-15.el9
-  sqlite                            rpm                                        3.34.1-9.el9_7
-  sqlite-libs                       rpm                                        3.34.1-9.el9_7
+  static                            docker  20260413-alpine3.23
-  systemd                           rpm                                        252-55.el9_7.8
-   └─  -  MEDIUM       CVE-2026-29111  [https://scout.docker.com/v/CVE-2026-29111] 7.8  Improper Validation of Specified Type of Input
-  systemd-libs                      rpm                                        252-55.el9_7.8
+  tzdata                            apk     2026b-r0
-  tzdata                            rpm                                        2026a-1.el9
-  util-linux                        rpm                                        2.37.4-21.el9_7
-   └─  -  MEDIUM       CVE-2025-14104  [https://scout.docker.com/v/CVE-2025-14104] 6.1  Out-of-bounds Read
-  xz                                rpm                                        5.2.5-8.el9_0
-  xz-libs                           rpm                                        5.2.5-8.el9_0
-  zlib                              rpm                                        1.2.11-40.el9
-   └─  -  HIGH         CVE-2026-22184  [https://scout.docker.com/v/CVE-2026-22184] 8.6  Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-  zstd                              rpm                                        1.5.5-1.el9
``` 