### PR TITLE
fix(rand): return errors for invalid random string inputs

### DIFF
--- a/pkg/util/rand/rand.go
+++ b/pkg/util/rand/rand.go
@@ -14,7 +14,16 @@ func String(n int) (string, error) {
 }
 
 // StringFromCharset generates, from a given charset, a cryptographically-secure pseudo-random string of a given length.
+//
+// Returns an error when n is negative, or when n > 0 and charset is empty.
+// n == 0 returns "" with no error regardless of the charset.
 func StringFromCharset(n int, charset string) (string, error) {
+	if n < 0 {
+		return "", fmt.Errorf("rand: requested length %d is negative", n)
+	}
+	if n > 0 && len(charset) == 0 {
+		return "", fmt.Errorf("rand: cannot generate %d-character string from empty charset", n)
+	}
 	b := make([]byte, n)
 	maxIdx := big.NewInt(int64(len(charset)))
 	for i := 0; i < n; i++ {

--- a/pkg/util/rand/rand_test.go
+++ b/pkg/util/rand/rand_test.go
@@ -1,0 +1,83 @@
+package rand
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestString_ValidLengths(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+	}{
+		{"zero length", 0},
+		{"single char", 1},
+		{"medium length", 24},
+		{"PKCE-style length", 43},
+		{"long", 128},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := String(tt.n)
+			require.NoError(t, err)
+			assert.Len(t, got, tt.n)
+			for i := 0; i < len(got); i++ {
+				assert.True(t, strings.IndexByte(letterBytes, got[i]) >= 0,
+					"byte %q at position %d not in default letter charset", got[i], i)
+			}
+		})
+	}
+}
+
+func TestString_NegativeLengthReturnsError(t *testing.T) {
+	got, err := String(-1)
+	require.Error(t, err)
+	assert.Equal(t, "", got)
+}
+
+func TestStringFromCharset_ValidInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		n       int
+		charset string
+	}{
+		{"empty length, empty charset", 0, ""},
+		{"empty length, non-empty charset", 0, "abc"},
+		{"single byte from single-byte charset", 1, "x"},
+		{"PKCE verifier charset", 43, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := StringFromCharset(tt.n, tt.charset)
+			require.NoError(t, err)
+			assert.Len(t, got, tt.n)
+			for i := 0; i < len(got); i++ {
+				assert.True(t, strings.IndexByte(tt.charset, got[i]) >= 0,
+					"byte %q at position %d not in charset %q", got[i], i, tt.charset)
+			}
+		})
+	}
+}
+
+func TestStringFromCharset_InvalidInputsReturnError(t *testing.T) {
+	tests := []struct {
+		name    string
+		n       int
+		charset string
+	}{
+		{"negative length, non-empty charset", -1, "abc"},
+		{"negative length, empty charset", -1, ""},
+		{"positive length, empty charset", 1, ""},
+		{"large positive length, empty charset", 100, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := StringFromCharset(tt.n, tt.charset)
+			require.Error(t, err)
+			assert.Equal(t, "", got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes two panic cases in `pkg/util/rand`. The helpers `String` and `StringFromCharset` both declare `(string, error)` returns, but two invalid inputs caused the process to panic instead of returning an error:

- `StringFromCharset(1, "")` panicked because `crypto/rand.Int` was called with `max = 0`.
- `String(-1)` panicked because `make([]byte, -1)` rejected the negative length.

This PR adds input validation before allocation and random-index generation, so invalid inputs now return descriptive errors instead of crashing the host process.

---

## Why

- Both functions already declare an `error` return; the panic paths were unreachable for callers who expected to handle them as errors.
- The SSO PKCE flow in `cmd/login.go` is the only current caller and is unaffected, because it always passes positive `n` and a non-empty charset.
- Adds the first unit tests to a package that previously had no test coverage.

---

## What changed

- Added two guard clauses at the top of `StringFromCharset`:
  - `n < 0` returns `"rand: requested length %d is negative"`.
  - `n > 0` with `len(charset) == 0` returns `"rand: cannot generate %d-character string from empty charset"`.
- `n == 0` continues to return `("", nil)` regardless of charset, preserving the existing no-op behavior.
- Updated the doc comment on `StringFromCharset` to spell out the new error contract.
- Added `pkg/util/rand/rand_test.go` with table-driven cases for both valid and invalid inputs. No statistical or distribution assertions — only deterministic length and charset-membership checks.

---

## Behavior preserved for valid inputs

```text
String(0)                     ->  "", nil
String(n)                     ->  string of length n, nil
StringFromCharset(0, "")      ->  "", nil
StringFromCharset(0, "abc")   ->  "", nil
StringFromCharset(10, "abc")  ->  10-character string using only a/b/c, nil
```

Public signatures are unchanged.

---

## Test plan

- [x] `gofmt -l pkg/util/rand/rand.go pkg/util/rand/rand_test.go` — no output
- [x] `git diff --check -- pkg/util/rand/rand.go pkg/util/rand/rand_test.go` — clean
- [x] `go test -v ./pkg/util/rand/...` — all cases pass
- [x] `go vet ./...` — clean
- [x] `go test ./...` — full sweep passes
- [x] `make build-local` — builds successfully

---

## Files changed

- `pkg/util/rand/rand.go` — two guard clauses + expanded doc comment.
- `pkg/util/rand/rand_test.go` — new file; first tests in this package.

---

## Notes

- I did not include `go test -cover` because my local Go toolchain reports `go: no such tool "covdata"`. The PR is scoped only to `pkg/util/rand` and its tests, so the missing coverage report does not affect the change itself; CI will produce a coverage report on its own toolchain if the project requires one.
- No production-code callers needed to change.
- No new dependencies.

Fixes #359
