### PR TITLE
Remove redundant Running status check

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -46,12 +46,6 @@ microcks start --name [name of you container/instance]`,
 			if instance == nil {
 				instance = &config.Instance{}
 			}
-
-			if instance.Status == "Running" {
-				fmt.Printf("Microcks instance with name %s is already running", name)
-				return
-			}
-
 			switch instance.Status {
 			case "Running":
 				fmt.Printf("Microcks instance with name %s is already running", name)


### PR DESCRIPTION
#### Summary

Removes a redundant `instance.Status == "Running"` check before the switch statement in the start command.

The `"Running"` case was already handled inside the switch, so the extra if-condition was unnecessary.

#### Changes

- Removed duplicate Running status check
- Kept existing behavior unchanged