### PR TITLE
test(cmd): add unit tests and flag validation for the test command

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -74,40 +74,15 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				os.Exit(1)
 			}
 
-			// Validate presence and values of flags.
-			if !strings.HasSuffix(waitFor, "milli") && !strings.HasSuffix(waitFor, "sec") && !strings.HasSuffix(waitFor, "min") {
-				fmt.Println("--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)")
-				os.Exit(1)
-			}
-
 			// Collect optional HTTPS transport flags.
 			config.InsecureTLS = globalClientOpts.InsecureTLS
 			config.CaCertPaths = globalClientOpts.CaCertPaths
 			config.Verbose = globalClientOpts.Verbose
 
-			// Compute time to wait in milliseconds.
-			var waitForMilliseconds int64
-			if strings.HasSuffix(waitFor, "milli") {
-				n, err := strconv.ParseInt(waitFor[:len(waitFor)-5], 0, 64)
-				if err != nil {
-					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
-					os.Exit(1)
-				}
-				waitForMilliseconds = n
-			} else if strings.HasSuffix(waitFor, "sec") {
-				n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
-				if err != nil {
-					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
-					os.Exit(1)
-				}
-				waitForMilliseconds = n * 1000
-			} else if strings.HasSuffix(waitFor, "min") {
-				n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
-				if err != nil {
-					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
-					os.Exit(1)
-				}
-				waitForMilliseconds = n * 60 * 1000
+			waitForMilliseconds, err := parseWaitFor(waitFor)
+			if err != nil {
+				fmt.Println(err.Error())
+				os.Exit(1)
 			}
 
 			var mc connectors.MicrocksClient
@@ -222,4 +197,27 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 func nowInMilliseconds() int64 {
 	return time.Now().UnixNano() / int64(time.Millisecond)
+}
+
+func parseWaitFor(waitFor string) (int64, error) {
+	if strings.HasSuffix(waitFor, "milli") {
+		n, err := strconv.ParseInt(waitFor[:len(waitFor)-5], 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("--waitFor value %q is not a valid number", waitFor)
+		}
+		return n, nil
+	} else if strings.HasSuffix(waitFor, "sec") {
+		n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("--waitFor value %q is not a valid number", waitFor)
+		}
+		return n * 1000, nil
+	} else if strings.HasSuffix(waitFor, "min") {
+		n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("--waitFor value %q is not a valid number", waitFor)
+		}
+		return n * 60 * 1000, nil
+	}
+	return 0, fmt.Errorf("--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)")
 }

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/microcks/microcks-cli/pkg/connectors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseWaitFor(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expected      int64
+		expectedError string
+	}{
+		{
+			name:     "Valid milliseconds",
+			input:    "500milli",
+			expected: 500,
+		},
+		{
+			name:     "Valid seconds",
+			input:    "5sec",
+			expected: 5000,
+		},
+		{
+			name:     "Valid minutes",
+			input:    "2min",
+			expected: 120000,
+		},
+		{
+			name:          "Invalid format",
+			input:         "5hours",
+			expectedError: "--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)",
+		},
+		{
+			name:          "Invalid number milli",
+			input:         "abcmilli",
+			expectedError: "--waitFor value \"abcmilli\" is not a valid number",
+		},
+		{
+			name:          "Invalid number sec",
+			input:         "xyzsec",
+			expectedError: "--waitFor value \"xyzsec\" is not a valid number",
+		},
+		{
+			name:          "Invalid number min",
+			input:         "1.5min",
+			expectedError: "--waitFor value \"1.5min\" is not a valid number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseWaitFor(tt.input)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestNewTestCommand(t *testing.T) {
+	clientOpts := &connectors.ClientOptions{}
+	cmd := NewTestCommand(clientOpts)
+
+	assert.Equal(t, "test", cmd.Use)
+	assert.Equal(t, "Run tests on Microcks", cmd.Short)
+
+	waitForFlag := cmd.Flags().Lookup("waitFor")
+	assert.NotNil(t, waitForFlag)
+	assert.Equal(t, "5sec", waitForFlag.DefValue)
+
+	secretNameFlag := cmd.Flags().Lookup("secretName")
+	assert.NotNil(t, secretNameFlag)
+
+	filteredOperationsFlag := cmd.Flags().Lookup("filteredOperations")
+	assert.NotNil(t, filteredOperationsFlag)
+
+	operationsHeadersFlag := cmd.Flags().Lookup("operationsHeaders")
+	assert.NotNil(t, operationsHeadersFlag)
+
+	oAuth2ContextFlag := cmd.Flags().Lookup("oAuth2Context")
+	assert.NotNil(t, oAuth2ContextFlag)
+}


### PR DESCRIPTION
### What does this PR do?
This PR introduces critical test coverage for the `test` command (`cmd/test.go`), which previously lacked a corresponding unit test file. 

Specifically, this PR:
1. **Refactors Flag Parsing**: Extracts the inline `--waitFor` string-parsing logic from the main `Run` block into an isolated, package-private `parseWaitFor` function.
2. **Adds Comprehensive Tests**: Introduces `cmd/test_test.go` with standard Go table-driven tests. These thoroughly validate the `parseWaitFor` logic, ensuring different units (`milli`, `sec`, `min`) are parsed correctly and mathematically sound.
3. **Verifies Command Wiring**: Adds a test block to ensure `NewTestCommand` initializes correctly with all expected flags and default values intact.

### Why is this important?
The `test` command is a core component of the `microcks-cli`. By extracting and testing the time-parsing logic, this PR prevents future regressions in how test timeouts are calculated, and ensures that invalid user input is handled gracefully.

### How to test this?
1. Check out this branch.
2. Run the tests in the `cmd` package:
   `go test -v ./cmd/test_test.go`
