### PR TITLE
docs(cli): fix command help typos, examples, and minor logging bugs

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -28,10 +28,10 @@ microcks start
 microcks start --port [Port you want]
 
 # Define your driver (by default docker)
-microcks start --driver [driver you wnat either 'docker' or 'podman']
+microcks start --driver [driver you want either 'docker' or 'podman']
 
 # Define name of your microcks container/instance
-microcks start --name [name of you container/instance]`,
+microcks start --name [name of your container/instance]`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			configFile := globalClientOpts.ConfigPath
@@ -143,10 +143,10 @@ microcks start --name [name of you container/instance]`,
 			fmt.Printf("Microcks started successfully at %s\n", server)
 		},
 	}
-	startCmd.Flags().StringVar(&name, "name", "microcks", "name for you microcks instance")
+	startCmd.Flags().StringVar(&name, "name", "microcks", "name for your microcks instance")
 	startCmd.Flags().StringVar(&hostPort, "port", "8585", "")
 	startCmd.Flags().StringVar(&imageName, "image", "quay.io/microcks/microcks-uber:latest-native", "image which will be used to create a container")
-	startCmd.Flags().BoolVar(&autoRemove, "rm", false, "mimic of '--rm' flag of dokcer to automatically remove the container when it exits")
+	startCmd.Flags().BoolVar(&autoRemove, "rm", false, "mimic of '--rm' flag of docker to automatically remove the container when it exits")
 	startCmd.Flags().StringVar(&driver, "driver", "docker", "use --driver to change driver from docker to podman")
 	return startCmd
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -16,6 +16,8 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 		Use:   "stop",
 		Short: "stop microcks instance",
 		Long:  "stop microcks instance",
+		Example: `# Stop the current Microcks instance
+microcks stop`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			configFile := globalClientOpts.ConfigPath

--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -345,7 +345,7 @@ func (l *LocalConfig) GetAuth(server string) (*Auth, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("Auth for '%s' is undifined", server)
+	return nil, fmt.Errorf("Auth for '%s' is undefined", server)
 }
 
 func (l *LocalConfig) UpsertAuth(auth Auth) {

--- a/pkg/watcher/executor.go
+++ b/pkg/watcher/executor.go
@@ -12,7 +12,7 @@ func TriggerImport(entry config.WatchEntry) {
 	// Retrieve config to get client options.
 	cfgPath, err := config.DefaultLocalConfigPath()
 	if err != nil {
-		fmt.Errorf("Error while loading config: %s", err.Error())
+		fmt.Printf("[ERROR] Error while loading config: %s\n", err.Error())
 	}
 
 	fmt.Println("[INFO] Re-importing changed file: " + entry.FilePath)


### PR DESCRIPTION
### What does this PR do?
This PR focuses on improving the Developer Experience (DX) of the CLI by cleaning up user-facing documentation strings and fixing minor linting/logging bugs.

Specifically, this PR:
1. **Fixes `start` Command Typos**: Corrects several spelling errors in the `--help` examples and flag descriptions of `cmd/start.go` (e.g., `wnat` -> `want`, `dokcer` -> `docker`, and missing 'r's in `your`).
2. **Improves `stop` Command DX**: Adds a missing `Example:` block to `cmd/stop.go` so that the usage output is consistent with the rest of the CLI.
3. **Fixes Silent Error in Watcher**: Replaces an orphaned, ignored `fmt.Errorf` call in `pkg/watcher/executor.go` with a proper `fmt.Printf("[ERROR] ...")` log so failures during config loading aren't swallowed silently.
4. **Fixes Typo in Config Package**: Corrects a hardcoded spelling error (`"undifined"`) returned by the `GetAuth` function.

### Why is this important?
Accurate `--help` commands are essential for good developer UX. Fixing these typos makes the CLI feel more polished and professional. Additionally, fixing the swallowed error in the `watcher` ensures that edge-case failures are properly communicated to the user.
