### PR TITLE
fix: replace silent return with os.Exit(1) on auth/config failures

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -55,7 +55,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 			if err != nil {
 				fmt.Println(err)
-				return
+				os.Exit(1)
 			}
 
 			// Prepare Microcks client.
@@ -101,7 +101,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				// Create client from config file and using the current or provided context.
 				if localConfig == nil {
 					fmt.Println("Please login to perform operation...")
-					return
+					os.Exit(1)
 				}
 
 				if globalClientOpts.Context == "" {
@@ -111,7 +111,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
 					fmt.Printf("error %v", err)
-					return
+					os.Exit(1)
 				}
 			}
 

--- a/cmd/importDir.go
+++ b/cmd/importDir.go
@@ -131,12 +131,12 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 			if err != nil {
 				fmt.Println(err)
-				return
+				os.Exit(1)
 			}
 
 			if localConfig == nil {
 				fmt.Println("Please login to perform operation...")
-				return
+				os.Exit(1)
 			}
 
 			if globalClientOpts.Context == "" {
@@ -147,7 +147,7 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			mc, err := connectors.NewClient(*globalClientOpts)
 			if err != nil {
 				fmt.Printf("error %v", err)
-				return
+				os.Exit(1)
 			}
 
 			// Set up business logic dependencies
@@ -163,7 +163,7 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			if err != nil {
 				if validationErr, ok := err.(*ValidationError); ok {
 					fmt.Println(validationErr.Message)
-					return
+					os.Exit(1)
 				}
 				fmt.Printf("Error: %v\n", err)
 				os.Exit(1)

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -77,12 +77,12 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 				localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 				if err != nil {
 					fmt.Println(err)
-					return
+					os.Exit(1)
 				}
 
 				if localConfig == nil {
 					fmt.Println("Please login to perform operation...")
-					return
+					os.Exit(1)
 				}
 
 				if globalClientOpts.Context == "" {
@@ -92,7 +92,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
 					fmt.Printf("error %v", err)
-					return
+					os.Exit(1)
 				}
 			}
 			sepSpecificationFiles := strings.Split(specificationFiles, ",")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -145,12 +145,12 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 				if err != nil {
 					fmt.Println(err)
-					return
+					os.Exit(1)
 				}
 
 				if localConfig == nil {
 					fmt.Println("Please login to perform operation...")
-					return
+					os.Exit(1)
 				}
 
 				if globalClientOpts.Context == "" {
@@ -160,7 +160,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
 					fmt.Printf("error %v", err)
-					return
+					os.Exit(1)
 				}
 
 				ctx, err := localConfig.ResolveContext(globalClientOpts.Context)


### PR DESCRIPTION
## Problem

In `cmd/test.go`, `cmd/import.go`, `cmd/importDir.go`, and `cmd/importURL.go`, several error branches inside the local-config path used plain `return` statements instead of `os.Exit(1)`:

- `config.ReadLocalConfig()` failure
- `localConfig == nil` (no login session)
- `connectors.NewClient()` failure
- `ValidationError` from `ImportDirectory`

Since Cobra treats a normal `Run` return as success, the process exited with **status 0** even when auth/config initialization failed. This caused CI/CD pipelines to report false-positive success - the command printed an error message but the pipeline saw a green exit code and continued.

## Changes

Replaced every silent `return` in these error branches with `os.Exit(1)` across all four affected files. No user-visible messages were changed.

| Scenario | Before | After |
|---|---|---|
| Missing/corrupt config file | exit 0 ❌ | exit 1 ✅ |
| No login session (`localConfig == nil`) | exit 0 ❌ | exit 1 ✅ |
| `NewClient()` failure | exit 0 ❌ | exit 1 ✅ |
| `ValidationError` from `ImportDirectory` | exit 0 ❌ | exit 1 ✅ |

## Files Changed

- `cmd/test.go` 
- `cmd/import.go` 
- `cmd/importDir.go` 
- `cmd/importURL.go` 
Fixes #361
