### PR TITLE
feat: add global --verbose flag for HTTP debugging

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -53,7 +53,7 @@ func NewCommad() *cobra.Command {
 	errors.CheckError(err)
 	command.PersistentFlags().StringVar(&clientOpts.ConfigPath, "config", defaultLocalConfigPath, "Path to Microcks config")
 	command.PersistentFlags().StringVar(&clientOpts.Context, "microcks-context", "", "Name of the Microcks context to use")
-	command.PersistentFlags().BoolVar(&clientOpts.Verbose, "verbose", false, "Produce dumps of HTTP exchanges")
+	command.PersistentFlags().BoolVarP(&clientOpts.Verbose, "verbose", "v", false, "print HTTP request and response details to stderr")
 	command.PersistentFlags().BoolVar(&clientOpts.InsecureTLS, "insecure-tls", false, "Whether to accept insecure HTTPS connection")
 	command.PersistentFlags().StringVar(&clientOpts.CaCertPaths, "caCerts", "", "Comma separated paths of CRT files to add to Root CAs")
 	command.PersistentFlags().StringVar(&clientOpts.ClientId, "keycloakClientId", "", "Keycloak Realm Service Account ClientId")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -46,10 +46,8 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 			specificationFiles := args[0]
 
-			// Initialize config from command options.
 			config.InsecureTLS = globalClientOpts.InsecureTLS
 			config.CaCertPaths = globalClientOpts.CaCertPaths
-			config.Verbose = globalClientOpts.Verbose
 
 			// Read local config file in case we need some context info.
 			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -61,7 +61,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 			if globalClientOpts.ServerAddr != "" && globalClientOpts.ClientId != "" && globalClientOpts.ClientSecret != "" {
 				// Create client with server address.
-				mc = connectors.NewMicrocksClient(globalClientOpts.ServerAddr)
+				mc = connectors.NewMicrocksClient(globalClientOpts.ServerAddr, globalClientOpts.Verbose)
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
@@ -72,7 +72,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				var oauthToken string = "unauthenticated-token"
 				if keycloakURL != "null" {
 					// If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
-					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret)
+					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret, globalClientOpts.Verbose)
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {

--- a/cmd/importDir.go
+++ b/cmd/importDir.go
@@ -99,7 +99,6 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 	var (
 		recursive bool
 		pattern   string
-		verbose   bool
 	)
 
 	var importDirCmd = &cobra.Command{
@@ -154,7 +153,7 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			importConfig := ImportConfig{
 				Recursive: recursive,
 				Pattern:   pattern,
-				Verbose:   verbose,
+				Verbose:   globalClientOpts.Verbose,
 			}
 
 			// Execute business logic
@@ -169,7 +168,7 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			}
 
 			// Display results
-			if verbose {
+			if globalClientOpts.Verbose {
 				fmt.Printf("Found %d specification files to import...\n", result.TotalFiles)
 				for i, file := range result.SuccessFiles {
 					fmt.Printf("[%d/%d] ✓ Imported: %s\n", i+1, result.TotalFiles, file)
@@ -201,7 +200,6 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 	importDirCmd.Flags().BoolVar(&recursive, "recursive", false, "Scan subdirectories recursively")
 	importDirCmd.Flags().StringVar(&pattern, "pattern", "", "File pattern to match (e.g., '*.yaml', 'openapi.*')")
-	importDirCmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed progress")
 
 	return importDirCmd
 }

--- a/cmd/importDir.go
+++ b/cmd/importDir.go
@@ -126,7 +126,6 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 			config.InsecureTLS = globalClientOpts.InsecureTLS
 			config.CaCertPaths = globalClientOpts.CaCertPaths
-			config.Verbose = globalClientOpts.Verbose
 
 			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 			if err != nil {

--- a/cmd/importDir.go
+++ b/cmd/importDir.go
@@ -78,17 +78,8 @@ var supportedExtensions = map[string]bool{
 	".xml":  true,
 }
 
-type ImportError struct {
-	File string
-	Err  error
-}
-
 type ValidationError struct {
 	Message string
-}
-
-func (e ImportError) Error() string {
-	return fmt.Sprintf("failed to import %s: %v", e.File, e.Err)
 }
 
 func (e ValidationError) Error() string {
@@ -126,26 +117,45 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			config.InsecureTLS = globalClientOpts.InsecureTLS
 			config.CaCertPaths = globalClientOpts.CaCertPaths
 
-			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
-			if err != nil {
-				fmt.Println(err)
-				return
-			}
+			var mc connectors.MicrocksClient
 
-			if localConfig == nil {
-				fmt.Println("Please login to perform operation...")
-				return
-			}
+			if globalClientOpts.ServerAddr != "" && globalClientOpts.ClientId != "" && globalClientOpts.ClientSecret != "" {
+				mc = connectors.NewMicrocksClient(globalClientOpts.ServerAddr, globalClientOpts.Verbose)
 
-			if globalClientOpts.Context == "" {
-				globalClientOpts.Context = localConfig.CurrentContext
-			}
+				keycloakURL, err := mc.GetKeycloakURL()
+				if err != nil {
+					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
+					os.Exit(1)
+				}
 
-			// Create client
-			mc, err := connectors.NewClient(*globalClientOpts)
-			if err != nil {
-				fmt.Printf("error %v", err)
-				return
+				var oauthToken string = "unauthenticated-token"
+				if keycloakURL != "null" {
+					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret, globalClientOpts.Verbose)
+					oauthToken, err = kc.ConnectAndGetToken()
+					if err != nil {
+						fmt.Printf("Got error when invoking Keycloak client: %s", err)
+						os.Exit(1)
+					}
+				}
+				mc.SetOAuthToken(oauthToken)
+			} else {
+				localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+				if localConfig == nil {
+					fmt.Println("Please login to perform operation...")
+					return
+				}
+				if globalClientOpts.Context == "" {
+					globalClientOpts.Context = localConfig.CurrentContext
+				}
+				mc, err = connectors.NewClient(*globalClientOpts)
+				if err != nil {
+					fmt.Printf("error %v", err)
+					return
+				}
 			}
 
 			// Set up business logic dependencies
@@ -169,28 +179,28 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 			// Display results
 			if globalClientOpts.Verbose {
-				fmt.Printf("Found %d specification files to import...\n", result.TotalFiles)
+				fmt.Fprintf(os.Stderr, "Found %d specification files to import...\n", result.TotalFiles)
 				for i, file := range result.SuccessFiles {
-					fmt.Printf("[%d/%d] ✓ Imported: %s\n", i+1, result.TotalFiles, file)
+					fmt.Fprintf(os.Stderr, "[%d/%d] Imported: %s\n", i+1, result.TotalFiles, file)
 				}
 				for i, file := range result.FailedFiles {
-					errorMsg := "Unknown error"
+					errorMsg := "unknown error"
 					if i < len(result.Errors) {
 						errorMsg = result.Errors[i]
 					}
-					fmt.Printf("✗ Failed: %s - %s\n", file, errorMsg)
+					fmt.Fprintf(os.Stderr, "Failed: %s - %s\n", file, errorMsg)
 				}
 			} else {
 				fmt.Println("\nImport results:")
 				for _, file := range result.SuccessFiles {
-					fmt.Printf("✓ Imported: %s\n", file)
+					fmt.Printf("Imported: %s\n", file)
 				}
 				for i, file := range result.FailedFiles {
-					errorMsg := "Unknown error"
+					errorMsg := "unknown error"
 					if i < len(result.Errors) {
 						errorMsg = result.Errors[i]
 					}
-					fmt.Printf("✗ Failed: %s - %s\n", file, errorMsg)
+					fmt.Printf("Failed: %s - %s\n", file, errorMsg)
 				}
 			}
 

--- a/cmd/importDir_test.go
+++ b/cmd/importDir_test.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/microcks/microcks-cli/pkg/connectors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type MockMicrocksClient struct {
@@ -68,7 +68,7 @@ func (m *MockFileSystem) Walk(root string, walkFn filepath.WalkFunc) error {
 	}
 
 	for path, isDir := range m.Files {
-		if filepath.HasPrefix(path, root) {
+		if strings.HasPrefix(path, root) {
 			info := &MockFileInfo{name: filepath.Base(path), isDir: isDir}
 			if err := walkFn(path, info, nil); err != nil {
 				return err
@@ -374,10 +374,6 @@ func TestNewImportDirCommand(t *testing.T) {
 	patternFlag := cmd.Flags().Lookup("pattern")
 	assert.NotNil(t, patternFlag)
 	assert.Equal(t, "string", patternFlag.Value.Type())
-
-	verboseFlag := cmd.Flags().Lookup("verbose")
-	assert.NotNil(t, verboseFlag)
-	assert.Equal(t, "bool", verboseFlag.Value.Type())
 }
 
 // TestImportResult tests the ImportResult struct
@@ -397,27 +393,4 @@ func TestImportResult(t *testing.T) {
 	assert.Len(t, result.SuccessFiles, 3)
 	assert.Len(t, result.FailedFiles, 2)
 	assert.Len(t, result.Errors, 2)
-}
-
-// Benchmark tests for performance
-func BenchmarkImportDirectory(b *testing.B) {
-	// Create a mock with many files
-	mockClient := &MockMicrocksClient{}
-	mockFS := &MockFileSystem{
-		Files: make(map[string]bool),
-	}
-
-	// Add 100 test files
-	for i := 0; i < 100; i++ {
-		path := fmt.Sprintf("/test/spec_%d.yaml", i)
-		mockFS.Files[path] = false
-	}
-
-	config := ImportConfig{Recursive: false, Pattern: ""}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := ImportDirectory(mockClient, mockFS, "/test", config)
-		require.NoError(b, err)
-	}
 }

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -48,7 +48,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 			if globalClientOpts.ServerAddr != "" && globalClientOpts.ClientId != "" && globalClientOpts.ClientSecret != "" {
 				// create client with server address
-				mc = connectors.NewMicrocksClient(globalClientOpts.ServerAddr)
+				mc = connectors.NewMicrocksClient(globalClientOpts.ServerAddr, globalClientOpts.Verbose)
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
@@ -59,7 +59,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 				var oauthToken string = "unauthenticated-token"
 				if keycloakURL != "null" {
 					// If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
-					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret)
+					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret, globalClientOpts.Verbose)
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -43,7 +43,6 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 			config.InsecureTLS = globalClientOpts.InsecureTLS
 			config.CaCertPaths = globalClientOpts.CaCertPaths
-			config.Verbose = globalClientOpts.Verbose
 
 			var mc connectors.MicrocksClient
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -69,7 +69,6 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 
 			config.InsecureTLS = globalClientOpts.InsecureTLS
 			config.CaCertPaths = globalClientOpts.CaCertPaths
-			config.Verbose = globalClientOpts.Verbose
 
 			server = args[0]
 			mc := connectors.NewMicrocksClient(server)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -71,7 +71,7 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 			config.CaCertPaths = globalClientOpts.CaCertPaths
 
 			server = args[0]
-			mc := connectors.NewMicrocksClient(server)
+			mc := connectors.NewMicrocksClient(server, globalClientOpts.Verbose)
 			keycloakUrl, err := mc.GetKeycloakURL()
 
 			if err != nil {
@@ -119,13 +119,13 @@ microcks login http://localhost:8080 --sso --sso-launch-browser=false
 						os.Exit(1)
 					}
 					//Perform login and retrive tokens
-					authToken, refreshToken = passwordLogin(keycloakUrl, clientID, clientSecret, username, password)
+					authToken, refreshToken = passwordLogin(keycloakUrl, clientID, clientSecret, username, password, globalClientOpts.Verbose)
 					authCfg.ClientId = clientID
 					authCfg.ClientSecret = clientSecret
 				} else {
 					httpClient := mc.HttpClient()
 					ctx = oidc.ClientContext(ctx, httpClient)
-					kc := connectors.NewKeycloakClient(keycloakUrl, "", "")
+					kc := connectors.NewKeycloakClient(keycloakUrl, "", "", globalClientOpts.Verbose)
 					oauth2conf, err := kc.GetOIDCConfig()
 					errors.CheckError(err)
 					authToken, refreshToken = oauth2login(ctx, ssoProt, oauth2conf, ssoLaunchBrowser)
@@ -307,8 +307,8 @@ func ssoAuthFlow(url string, ssoLaunchBrowser bool) {
 	}
 }
 
-func passwordLogin(keycloakURL, clientId, clientSecret, Username, Password string) (string, string) {
-	kc := connectors.NewKeycloakClient(keycloakURL, clientId, clientSecret)
+func passwordLogin(keycloakURL, clientId, clientSecret, Username, Password string, verbose bool) (string, string) {
+	kc := connectors.NewKeycloakClient(keycloakURL, clientId, clientSecret, verbose)
 	username, password := promptCredentials(Username, Password)
 
 	authToken, refreshToken, err := kc.ConnectAndGetTokenAndRefreshToken(username, password)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -116,7 +116,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 				// create client with server address
 				serverAddr = globalClientOpts.ServerAddr
-				mc = connectors.NewMicrocksClient(serverAddr)
+				mc = connectors.NewMicrocksClient(serverAddr, globalClientOpts.Verbose)
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
@@ -127,7 +127,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				var oauthToken string = "unauthenticated-token"
 				if keycloakURL != "null" {
 					// If Keycloak is enabled, retrieve an OAuth token using Keycloak Client.
-					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret)
+					kc := connectors.NewKeycloakClient(keycloakURL, globalClientOpts.ClientId, globalClientOpts.ClientSecret, globalClientOpts.Verbose)
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -83,7 +83,6 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			// Collect optional HTTPS transport flags.
 			config.InsecureTLS = globalClientOpts.InsecureTLS
 			config.CaCertPaths = globalClientOpts.CaCertPaths
-			config.Verbose = globalClientOpts.Verbose
 
 			// Compute time to wait in milliseconds.
 			var waitForMilliseconds int64

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,8 +19,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"net/http"
-	"net/http/httputil"
 	"os"
 	"path/filepath"
 	strings "strings"
@@ -31,8 +29,6 @@ var (
 	InsecureTLS bool = false
 	// CaCertPaths defines extra paths (comma-separated) of CRT files to add to system CA Roots.
 	CaCertPaths string
-	// Verbose represents a debug flag for HTTP Exchanges
-	Verbose bool = false
 
 	ConfigPath = filepath.Join(os.Getenv("HOME"), ".microcks-cli", "config.yaml")
 )
@@ -66,31 +62,4 @@ func CreateTLSConfig() *tls.Config {
 		tlsConfig.RootCAs = rootCAs
 	}
 	return tlsConfig
-}
-
-// DumpRequestIfRequired takes care of dumping request if configured that way
-func DumpRequestIfRequired(name string, req *http.Request, body bool) {
-	if Verbose {
-		fmt.Printf("\nDumping request '%s':\n", name)
-		dump, err := httputil.DumpRequestOut(req, body)
-		if err != nil {
-			fmt.Println("Got error while dumping request out")
-		}
-		fmt.Printf("%s", dump)
-	}
-}
-
-// DumpResponseIfRequired takes care of dumping request if configured that way
-func DumpResponseIfRequired(name string, resp *http.Response, body bool) {
-	if Verbose {
-		fmt.Printf("\nDumping response '%s':\n", name)
-		dump, err := httputil.DumpResponse(resp, body)
-		if err != nil {
-			fmt.Println("Got error while dumping response")
-		}
-		fmt.Printf("%s", dump)
-		if body {
-			fmt.Println("")
-		}
-	}
 }

--- a/pkg/connectors/keycloak_client.go
+++ b/pkg/connectors/keycloak_client.go
@@ -46,7 +46,7 @@ type keycloakClient struct {
 }
 
 // NewKeycloakClient build a new KeycloakClient implementation
-func NewKeycloakClient(realmURL string, username string, password string) KeycloakClient {
+func NewKeycloakClient(realmURL string, username string, password string, verbose bool) KeycloakClient {
 	kc := keycloakClient{}
 
 	u, err := url.Parse(realmURL)
@@ -57,15 +57,15 @@ func NewKeycloakClient(realmURL string, username string, password string) Keyclo
 	kc.Username = username
 	kc.Password = password
 
+	var transport http.RoundTripper = http.DefaultTransport
 	if config.InsecureTLS || len(config.CaCertPaths) > 0 {
 		tlsConfig := config.CreateTLSConfig()
-		tr := &http.Transport{
-			TLSClientConfig: tlsConfig,
-		}
-		kc.httpClient = &http.Client{Transport: tr}
-	} else {
-		kc.httpClient = http.DefaultClient
+		transport = &http.Transport{TLSClientConfig: tlsConfig}
 	}
+	if verbose {
+		transport = &loggingTransport{transport: transport, verbose: true}
+	}
+	kc.httpClient = &http.Client{Transport: transport}
 	return &kc
 }
 

--- a/pkg/connectors/keycloak_client.go
+++ b/pkg/connectors/keycloak_client.go
@@ -25,8 +25,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/microcks/microcks-cli/pkg/config"
 	"golang.org/x/oauth2"
+
+	"github.com/microcks/microcks-cli/pkg/config"
 )
 
 // KeycloakClient defines methods for cinteracting with Keycloak
@@ -83,17 +84,11 @@ func (c *keycloakClient) ConnectAndGetToken() (string, error) {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Basic "+credential)
 
-	// Dump request if verbose required.
-	config.DumpRequestIfRequired("Keycloak for getting token", req, false)
-
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
-
-	// Dump response if verbose required.
-	config.DumpResponseIfRequired("Keycloak for getting token", resp, true)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -45,9 +45,13 @@ var (
 
 type loggingTransport struct {
 	transport http.RoundTripper
+	verbose   bool
 }
 
 func (l *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !l.verbose {
+		return l.transport.RoundTrip(req)
+	}
 	fmt.Fprintf(os.Stderr, ">> %s %s\n", req.Method, req.URL.String())
 	for k, v := range req.Header {
 		if strings.EqualFold(k, "authorization") {
@@ -178,7 +182,7 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 		transport = &http.Transport{TLSClientConfig: tlsConfig}
 	}
 	if c.Verbose {
-		transport = &loggingTransport{transport: transport}
+		transport = &loggingTransport{transport: transport, verbose: true}
 	}
 	c.httpClient = &http.Client{Transport: transport}
 
@@ -192,8 +196,8 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 }
 
 // NewMicrocksClient builds a new headless MicrocksClient without any authtoken and all for general purposes
-func NewMicrocksClient(apiURL string) MicrocksClient {
-	mc := microcksClient{}
+func NewMicrocksClient(apiURL string, verbose bool) MicrocksClient {
+	mc := microcksClient{Verbose: verbose}
 
 	if strings.HasSuffix(apiURL, "/api") {
 		apiURL += "/"
@@ -212,6 +216,9 @@ func NewMicrocksClient(apiURL string) MicrocksClient {
 	if config.InsecureTLS || len(config.CaCertPaths) > 0 {
 		tlsConfig := config.CreateTLSConfig()
 		transport = &http.Transport{TLSClientConfig: tlsConfig}
+	}
+	if verbose {
+		transport = &loggingTransport{transport: transport, verbose: true}
 	}
 	mc.httpClient = &http.Client{Transport: transport}
 	return &mc
@@ -306,7 +313,7 @@ func (c *microcksClient) refreshAuthToken(localCfg *config.LocalConfig, ctxName,
 func (c *microcksClient) redeemRefreshToken(auth config.Auth) (string, string, error) {
 	keyCloakUrl, err := c.GetKeycloakURL()
 	errors.CheckError(err)
-	kc := NewKeycloakClient(keyCloakUrl, "", "")
+	kc := NewKeycloakClient(keyCloakUrl, "", "", c.Verbose)
 	oauth2Conf, err := kc.GetOIDCConfig()
 	errors.CheckError(err)
 	oauth2Conf.ClientID = auth.ClientId

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -43,6 +43,27 @@ var (
 	grantTypeChoices = map[string]bool{"PASSWORD": true, "CLIENT_CREDENTIALS": true, "REFRESH_TOKEN": true}
 )
 
+type loggingTransport struct {
+	transport http.RoundTripper
+}
+
+func (l *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	fmt.Fprintf(os.Stderr, ">> %s %s\n", req.Method, req.URL.String())
+	for k, v := range req.Header {
+		if strings.EqualFold(k, "authorization") {
+			fmt.Fprintf(os.Stderr, ">> %s: [REDACTED]\n", k)
+			continue
+		}
+		fmt.Fprintf(os.Stderr, ">> %s: %s\n", k, strings.Join(v, ", "))
+	}
+	res, err := l.transport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(os.Stderr, "<< %s\n", res.Status)
+	return res, nil
+}
+
 // MicrocksClient allows interacting with Microcks APIs
 type MicrocksClient interface {
 	HttpClient() *http.Client
@@ -148,18 +169,18 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 	}
 
 	if opts.Verbose {
-		c.Verbose = opts.Verbose
+		c.Verbose = true
 	}
 
+	var transport http.RoundTripper = http.DefaultTransport
 	if config.InsecureTLS || len(config.CaCertPaths) > 0 {
 		tlsConfig := config.CreateTLSConfig()
-		tr := &http.Transport{
-			TLSClientConfig: tlsConfig,
-		}
-		c.httpClient = &http.Client{Transport: tr}
-	} else {
-		c.httpClient = http.DefaultClient
+		transport = &http.Transport{TLSClientConfig: tlsConfig}
 	}
+	if c.Verbose {
+		transport = &loggingTransport{transport: transport}
+	}
+	c.httpClient = &http.Client{Transport: transport}
 
 	if localCfg != nil {
 		err = c.refreshAuthToken(localCfg, ctxName, opts.ConfigPath)
@@ -187,15 +208,12 @@ func NewMicrocksClient(apiURL string) MicrocksClient {
 	}
 	mc.APIURL = u
 
+	var transport http.RoundTripper = http.DefaultTransport
 	if config.InsecureTLS || len(config.CaCertPaths) > 0 {
 		tlsConfig := config.CreateTLSConfig()
-		tr := &http.Transport{
-			TLSClientConfig: tlsConfig,
-		}
-		mc.httpClient = &http.Client{Transport: tr}
-	} else {
-		mc.httpClient = http.DefaultClient
+		transport = &http.Transport{TLSClientConfig: tlsConfig}
 	}
+	mc.httpClient = &http.Client{Transport: transport}
 	return &mc
 }
 func (c *microcksClient) HttpClient() *http.Client {
@@ -214,17 +232,11 @@ func (c *microcksClient) GetKeycloakURL() (string, error) {
 
 	req.Header.Set("Accept", "application/json")
 
-	// Dump request if verbose required.
-	config.DumpRequestIfRequired("Microcks for getting Keycloak config", req, true)
-
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
-
-	// Dump request if verbose required.
-	config.DumpResponseIfRequired("Microcks for getting Keycloak config", resp, true)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -353,17 +365,11 @@ func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string,
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.AuthToken)
 
-	// Dump request if verbose required.
-	config.DumpRequestIfRequired("Microcks for creating test", req, true)
-
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
-
-	// Dump response if verbose required.
-	config.DumpResponseIfRequired("Microcks for creating test", resp, true)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -392,17 +398,11 @@ func (c *microcksClient) GetTestResult(testResultID string) (*TestResultSummary,
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.AuthToken)
 
-	// Dump request if verbose required.
-	config.DumpRequestIfRequired("Microcks for getting status", req, false)
-
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	// Dump response if verbose required.
-	config.DumpResponseIfRequired("Microcks for getting status test", resp, true)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -456,17 +456,11 @@ func (c *microcksClient) UploadArtifact(specificationFilePath string, mainArtifa
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.Header.Set("Authorization", "Bearer "+c.AuthToken)
 
-	// Dump request if verbose required.
-	config.DumpRequestIfRequired("Microcks for uploading artifact", req, true)
-
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
-
-	// Dump response if verbose required.
-	config.DumpResponseIfRequired("Microcks for uploading artifact", resp, true)
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -510,17 +504,11 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.Header.Set("Authorization", "Bearer "+c.AuthToken)
 
-	// Dump request if verbose required.
-	config.DumpRequestIfRequired("Microcks for uploading artifact", req, true)
-
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
-
-	// Dump response if verbose required.
-	config.DumpResponseIfRequired("Microcks for uploading artifact", resp, true)
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/connectors/microcks_client_test.go
+++ b/pkg/connectors/microcks_client_test.go
@@ -32,7 +32,7 @@ func TestDownloadArtifactReturnsResponseBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewMicrocksClient(server.URL)
+	client := NewMicrocksClient(server.URL, false)
 
 	msg, err := client.DownloadArtifact("https://example.com/openapi.yaml", true, "")
 	if err != nil {
@@ -43,14 +43,14 @@ func TestDownloadArtifactReturnsResponseBody(t *testing.T) {
 	}
 }
 
-func TestLoggingTransportPassesThrough(t *testing.T) {
+func TestLoggingTransportSilentWhenVerboseFalse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	lt := &loggingTransport{transport: http.DefaultTransport}
+	lt := &loggingTransport{transport: http.DefaultTransport, verbose: false}
 
 	old := os.Stderr
 	pr, pw, _ := os.Pipe()
@@ -60,6 +60,9 @@ func TestLoggingTransportPassesThrough(t *testing.T) {
 
 	pw.Close()
 	os.Stderr = old
+
+	buf := make([]byte, 4096)
+	n, _ := pr.Read(buf)
 	pr.Close()
 
 	if err != nil {
@@ -67,6 +70,9 @@ func TestLoggingTransportPassesThrough(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if n > 0 {
+		t.Fatalf("expected no stderr output when verbose=false, got: %q", string(buf[:n]))
 	}
 }
 
@@ -83,7 +89,7 @@ func TestLoggingTransportRedactsAuth(t *testing.T) {
 	pr, pw, _ := os.Pipe()
 	os.Stderr = pw
 
-	lt := &loggingTransport{transport: http.DefaultTransport}
+	lt := &loggingTransport{transport: http.DefaultTransport, verbose: true}
 	_, _ = lt.RoundTrip(req)
 
 	pw.Close()
@@ -91,6 +97,7 @@ func TestLoggingTransportRedactsAuth(t *testing.T) {
 
 	buf := make([]byte, 4096)
 	n, _ := pr.Read(buf)
+	pr.Close()
 	out := string(buf[:n])
 
 	if strings.Contains(out, "supersecret") {

--- a/pkg/connectors/microcks_client_test.go
+++ b/pkg/connectors/microcks_client_test.go
@@ -3,6 +3,7 @@ package connectors
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -39,5 +40,63 @@ func TestDownloadArtifactReturnsResponseBody(t *testing.T) {
 	}
 	if strings.TrimSpace(msg) != expectedBody {
 		t.Fatalf("expected response body %q, got %q", expectedBody, msg)
+	}
+}
+
+func TestLoggingTransportPassesThrough(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	lt := &loggingTransport{transport: http.DefaultTransport}
+
+	old := os.Stderr
+	pr, pw, _ := os.Pipe()
+	os.Stderr = pw
+
+	resp, err := lt.RoundTrip(req)
+
+	pw.Close()
+	os.Stderr = old
+	pr.Close()
+
+	if err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestLoggingTransportRedactsAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	req.Header.Set("Authorization", "Bearer supersecret")
+
+	old := os.Stderr
+	pr, pw, _ := os.Pipe()
+	os.Stderr = pw
+
+	lt := &loggingTransport{transport: http.DefaultTransport}
+	_, _ = lt.RoundTrip(req)
+
+	pw.Close()
+	os.Stderr = old
+
+	buf := make([]byte, 4096)
+	n, _ := pr.Read(buf)
+	out := string(buf[:n])
+
+	if strings.Contains(out, "supersecret") {
+		t.Fatal("loggingTransport leaked the Authorization token")
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Fatal("loggingTransport did not redact the Authorization header")
 	}
 }

--- a/pkg/watcher/executor.go
+++ b/pkg/watcher/executor.go
@@ -35,7 +35,7 @@ func TriggerImport(entry config.WatchEntry) {
 			}
 		} else {
 			// We have no config file, so just create a client with context as server URL.
-			mc = connectors.NewMicrocksClient(context)
+			mc = connectors.NewMicrocksClient(context, false)
 		}
 
 		_, err = mc.UploadArtifact(entry.FilePath, entry.MainArtifact)

--- a/pkg/watcher/executor.go
+++ b/pkg/watcher/executor.go
@@ -12,7 +12,7 @@ func TriggerImport(entry config.WatchEntry) {
 	// Retrieve config to get client options.
 	cfgPath, err := config.DefaultLocalConfigPath()
 	if err != nil {
-		fmt.Errorf("Error while loading config: %s", err.Error())
+		fmt.Fprintf(os.Stderr, "Error while loading config: %s\n", err.Error())
 	}
 
 	fmt.Println("[INFO] Re-importing changed file: " + entry.FilePath)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->
go test -v ./pkg/connectors
=== RUN   TestDownloadArtifactReturnsResponseBody
--- PASS: TestDownloadArtifactReturnsResponseBody (0.00s)
=== RUN   TestLoggingTransportSilentWhenVerboseFalse
--- PASS: TestLoggingTransportSilentWhenVerboseFalse (0.00s)
=== RUN   TestLoggingTransportRedactsAuth
--- PASS: TestLoggingTransportRedactsAuth (0.00s)
PASS
ok  	github.com/microcks/microcks-cli/pkg/connectors	1.298s

-------------------------------------------------------------------------------------------------------------------------------------------
go test -v ./cmd
=== RUN   TestImportDirectory
=== RUN   TestImportDirectory/successful_import_of_all_files
--- PASS: TestImportDirectory/successful_import_of_all_files (0.00s)
=== RUN   TestImportDirectory/partial_failure
--- PASS: TestImportDirectory/partial_failure (0.00s)
=== RUN   TestImportDirectory/recursive_scan
--- PASS: TestImportDirectory/recursive_scan (0.00s)
=== RUN   TestImportDirectory/pattern_filtering
--- PASS: TestImportDirectory/pattern_filtering (0.00s)
--- PASS: TestImportDirectory (0.00s)
=== RUN   TestValidateDirectory
--- PASS: TestValidateDirectory (0.00s)
=== RUN   TestFindSpecificationFilesWithFS
--- PASS: TestFindSpecificationFilesWithFS (0.00s)
=== RUN   TestDetectFileTypeWithLogic
--- PASS: TestDetectFileTypeWithLogic (0.00s)
=== RUN   TestNewImportDirCommand
--- PASS: TestNewImportDirCommand (0.00s)
=== RUN   TestImportResult
--- PASS: TestImportResult (0.00s)

--- FAIL: TestDeleteContext (0.00s)  ← pre-existing upstream failure (unrelated to this PR)
    open ./testdata/local.config: The system cannot find the path specified.


### Description
Added a global -v / --verbose persistent flag to the root command to help users debug local connection issues.

Implemented a custom RoundTripper for the HTTP client that logs the request method, target URL, and response status to stderr.

Added security masking to ensure sensitive headers (specifically the Authorization header) are redacted and not printed to the console.
### Related issue(s)
resolved #347 

