### PR TITLE
fix: read from response body in DownloadArtifact

### DIFF
--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -520,7 +520,7 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 	// Dump response if verbose required.
 	config.DumpResponseIfRequired("Microcks for uploading artifact", resp, true)
 
-	respBody, err := io.ReadAll(req.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION

### Description

When using import-url, the CLI was showing an empty message:
Microcks has discovered ''.

This happened because the code was reading the response from the wrong place (req.Body instead of resp.Body), so it couldn’t get the server message

**before solving it :**

<img width="1066" height="213" alt="image" src="https://github.com/user-attachments/assets/5c45e379-0a94-409d-bef6-c00c507ec1fc" />

**after solving it**

<img width="1066" height="213" alt="Screenshot from 2026-05-12 23-26-10" src="https://github.com/user-attachments/assets/f0fcc93e-60df-48f1-9a23-30b1d59f46b7" />

### Related issue(s) #375