### PR TITLE
Fix manual json return

### DIFF
--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -318,33 +318,52 @@ func (c *microcksClient) SetOAuthToken(oauthToken string) {
 	c.AuthToken = oauthToken
 }
 
+// testRequest represents a request for creating a new TestResult
+type testRequest struct {
+	ServiceID          string               `json:"serviceId"`
+	TestEndpoint       string               `json:"testEndpoint"`
+	RunnerType         string               `json:"runnerType"`
+	Timeout            int64                `json:"timeout"`
+	SecretName         string               `json:"secretName,omitempty"`
+	FilteredOperations json.RawMessage      `json:"filteredOperations,omitempty"`
+	OperationsHeaders  json.RawMessage      `json:"operationsHeaders,omitempty"`
+	OAuth2Context      *OAuth2ClientContext `json:"oAuth2Context,omitempty"`
+}
+
 func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string, runnerType string, secretName string, timeout int64, filteredOperations string, operationsHeaders string, oAuth2Context string) (string, error) {
 	// Ensure we have a correct URL.
 	rel := &url.URL{Path: "tests"}
 	u := c.APIURL.ResolveReference(rel)
 
-	// Prepare an input string as body.
-	var input = "{"
-	input += ("\"serviceId\": \"" + serviceID + "\", ")
-	input += ("\"testEndpoint\": \"" + testEndpoint + "\", ")
-	input += ("\"runnerType\": \"" + runnerType + "\", ")
-	input += ("\"timeout\":  " + strconv.FormatInt(timeout, 10))
+	// Prepare an input struct as body.
+	request := testRequest{
+		ServiceID:    serviceID,
+		TestEndpoint: testEndpoint,
+		RunnerType:   runnerType,
+		Timeout:      timeout,
+	}
 	if len(secretName) > 0 {
-		input += (", \"secretName\": \"" + secretName + "\"")
+		request.SecretName = secretName
 	}
 	if len(filteredOperations) > 0 && ensureValidOperationsList(filteredOperations) {
-		input += (", \"filteredOperations\": " + filteredOperations)
+		request.FilteredOperations = json.RawMessage(filteredOperations)
 	}
 	if len(operationsHeaders) > 0 && ensureValidOperationsHeaders(operationsHeaders) {
-		input += (", \"operationsHeaders\": " + operationsHeaders)
+		request.OperationsHeaders = json.RawMessage(operationsHeaders)
 	}
-	if len(oAuth2Context) > 0 && ensureValieOAuth2Context(oAuth2Context) {
-		input += (", \"oAuth2Context\": " + oAuth2Context)
+	if len(oAuth2Context) > 0 {
+		oContext, valid := ensureValidOAuth2Context(oAuth2Context)
+		if valid {
+			request.OAuth2Context = oContext
+		}
 	}
 
-	input += "}"
+	input, err := json.Marshal(request)
+	if err != nil {
+		return "", err
+	}
 
-	req, err := http.NewRequest("POST", u.String(), strings.NewReader(input))
+	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(input))
 	if err != nil {
 		return "", err
 	}
@@ -555,16 +574,17 @@ func ensureValidOperationsHeaders(operationsHeaders string) bool {
 	return true
 }
 
-func ensureValieOAuth2Context(oAuth2Context string) bool {
+func ensureValidOAuth2Context(oAuth2Context string) (*OAuth2ClientContext, bool) {
 	var oContext = OAuth2ClientContext{}
 	err := json.Unmarshal([]byte(oAuth2Context), &oContext)
 	if err != nil {
 		fmt.Println("Error parsing JSON in oAuth2Context: ", err)
-		return false
+		return nil, false
 	}
 	if !grantTypeChoices[oContext.GrantType] {
 		fmt.Println("grantType in oAuth2Context is not supported. OAuth2 is turned off.")
-		return false
+		return nil, false
 	}
-	return true
+	return &oContext, true
 }
+


### PR DESCRIPTION

### Description
This PR improves how the `CreateTestResult()` request payload is built by replacing manual JSON string concatenation with a structured approach using Go structs and `json.Marshal().`

Previously, building the JSON manually could lead to issues when values contained special characters like quotes or backslashes. This refactor makes the request generation safer and more reliable.

**What changed**

- Introduced a testRequest struct to represent the API payload.
- Replaced manual string building with json.Marshal().
- Improved handling of complex fields using json.RawMessage.
- Fixed a typo in ensureValidOAuth2Context.
- Improved OAuth2 context parsing and validation.

**Impact**

- Safer JSON generation
- Better code readability and maintainability
- Fewer potential runtime bugs from malformed payloads

**before solving it**

<img width="1177" height="467" alt="Screenshot from 2026-05-13 02-15-09" src="https://github.com/user-attachments/assets/2cf97612-64c7-47bb-990a-ffd6a78bf961" />


**after solving it**

<img width="1094" height="467" alt="Screenshot from 2026-05-13 02-09-49" src="https://github.com/user-attachments/assets/220a2baf-54f9-4235-9a83-16113938ef39" />


### Related issue(s) : #377
