### PR TITLE
fix: cves patch with go 1.25.10

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build binary
-FROM --platform=$BUILDPLATFORM golang:1.25.9-alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS build-env
 ADD . /app
 WORKDIR /app
 ARG TARGETOS
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags="-s -w" -o microcks github.com/microcks/microcks-cli
     
 # Build image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
 
 # Some version information
 LABEL maintainer="Laurent Broudoux <laurent@microcks.io>" \

--- a/build/Dockerfile.dhi
+++ b/build/Dockerfile.dhi
@@ -1,5 +1,5 @@
 # Build binary
-FROM --platform=$BUILDPLATFORM dhi.io/golang:1.25.9-alpine3.23-dev AS build-env
+FROM --platform=$BUILDPLATFORM dhi.io/golang:1.25.10-alpine3.23-dev AS build-env
 ADD . /app
 WORKDIR /app
 ARG TARGETOS


### PR DESCRIPTION
fix: CVEs patch with go 1.25.10 for the 2 container images.

_Note: not upgrading to go 1.26 as in `go.mod` it's for now in 1.25, something that could be done in a further and dedicated PR._

Diff for the default container:
<img width="2244" height="698" alt="image" src="https://github.com/user-attachments/assets/b4fc5215-1a41-40e7-ba80-3e02930e77ef" />

```diff
+ libcap        rpm     2.48-10.el9_7.1  2.48-10.el9
+ stdlib        golang  1.25.10          1.25.9
-     ├─   HIGH         CVE-2026-42499  [https://scout.docker.com/v/CVE-2026-42499] 7.5
-     ├─   HIGH         CVE-2026-39836  [https://scout.docker.com/v/CVE-2026-39836] 7.5
-     ├─   HIGH         CVE-2026-39820  [https://scout.docker.com/v/CVE-2026-39820] 7.5
-     ├─   HIGH         CVE-2026-33814  [https://scout.docker.com/v/CVE-2026-33814] 7.5
-     ├─   HIGH         CVE-2026-33811  [https://scout.docker.com/v/CVE-2026-33811] 7.5
-     ├─   MEDIUM       CVE-2026-39826  [https://scout.docker.com/v/CVE-2026-39826] 6.1
-     ├─   MEDIUM       CVE-2026-39823  [https://scout.docker.com/v/CVE-2026-39823] 6.1
-     └─   MEDIUM       CVE-2026-39825  [https://scout.docker.com/v/CVE-2026-39825] 5.3
+ systemd       rpm     252-55.el9_7.9   252-55.el9_7.8
+ systemd-libs  rpm     252-55.el9_7.9   252-55.el9_7.8
```

Diffs for the `distroless` container:
<img width="2238" height="526" alt="image" src="https://github.com/user-attachments/assets/804714af-5c8a-4b87-ba1d-0263f1906a07" />

```diff
+ stdlib        golang  1.25.10          1.25.9
-     ├─   HIGH         CVE-2026-42499  [https://scout.docker.com/v/CVE-2026-42499] 7.5
-     ├─   HIGH         CVE-2026-39836  [https://scout.docker.com/v/CVE-2026-39836] 7.5
-     ├─   HIGH         CVE-2026-39820  [https://scout.docker.com/v/CVE-2026-39820] 7.5
-     ├─   HIGH         CVE-2026-33814  [https://scout.docker.com/v/CVE-2026-33814] 7.5
-     ├─   HIGH         CVE-2026-33811  [https://scout.docker.com/v/CVE-2026-33811] 7.5
-     ├─   MEDIUM       CVE-2026-39826  [https://scout.docker.com/v/CVE-2026-39826] 6.1
-     ├─   MEDIUM       CVE-2026-39823  [https://scout.docker.com/v/CVE-2026-39823] 6.1
-     └─   MEDIUM       CVE-2026-39825  [https://scout.docker.com/v/CVE-2026-39825] 5.3
```

