### PR TITLE
  test: fix context deletion test setup and assert config cleanup

### DIFF
--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/microcks/microcks-cli/pkg/config"
@@ -36,9 +37,9 @@ users:
   auth-token: ""
   refresh-token: ""`
 
-const testConfigFilePath = "./testdata/local.config"
-
 func TestDeleteContext(t *testing.T) {
+	testConfigFilePath := filepath.Join(t.TempDir(), "local.config")
+
 	//write the test config file
 	err := os.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
 	require.NoError(t, err)
@@ -61,6 +62,9 @@ func TestDeleteContext(t *testing.T) {
 	//Delete current context
 	err = deleteContext("http://localhost:8083", testConfigFilePath)
 	require.NoError(t, err)
-	_, err = config.ReadLocalConfig(testConfigFilePath)
+	localCfg, err = config.ReadLocalConfig(testConfigFilePath)
 	require.NoError(t, err)
+	assert.Nil(t, localCfg)
+	_, err = os.Stat(testConfigFilePath)
+	assert.True(t, os.IsNotExist(err))
 }


### PR DESCRIPTION
  ### Summary

  This PR fixes `TestDeleteContext` in `cmd/context_test.go`.

  The test previously wrote to `./testdata/local.config`, but `cmd/testdata/` does not exist in the repository, causing `go test ./cmd` to fail before exercising the actual
  context deletion logic.

  ### Changes

  - replace the hardcoded `./testdata/local.config` path with a file under `t.TempDir()`
  - keep the test isolated from repository-local filesystem state
  - add an assertion for the last-context deletion path:
    - `ReadLocalConfig()` returns `nil`
    - the config file is removed from disk

  ### Why

  This makes the test reliable and covers the `localCfg.IsEmpty()` branch in `deleteContext()`.

  ### Verification

  ```bash
  go test ./cmd
```


Previous Failure
<img width="708" height="334" alt="Screenshot from 2026-05-14 23-11-59" src="https://github.com/user-attachments/assets/690abd59-c0bc-48cc-b2d2-b2a7899e257a" />


