### PR TITLE
refactor: use struct for test request and fix CLI typo

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCommad() *cobra.Command {
+func NewCommand() *cobra.Command {
 
 	var clientOpts connectors.ClientOptions
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	command := cmd.NewCommad()
+	command := cmd.NewCommand()
 	if err := command.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -110,6 +110,17 @@ type microcksClient struct {
 	httpClient *http.Client
 }
 
+type testRequest struct {
+	ServiceID          string          `json:"serviceId"`
+	TestEndpoint       string          `json:"testEndpoint"`
+	RunnerType         string          `json:"runnerType"`
+	Timeout            int64           `json:"timeout"`
+	SecretName         string          `json:"secretName,omitempty"`
+	FilteredOperations json.RawMessage `json:"filteredOperations,omitempty"`
+	OperationsHeaders  json.RawMessage `json:"operationsHeaders,omitempty"`
+	OAuth2Context      json.RawMessage `json:"oAuth2Context,omitempty"`
+}
+
 func NewClient(opts ClientOptions) (MicrocksClient, error) {
 	var c microcksClient
 	localCfg, err := config.ReadLocalConfig(opts.ConfigPath)
@@ -323,28 +334,31 @@ func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string,
 	rel := &url.URL{Path: "tests"}
 	u := c.APIURL.ResolveReference(rel)
 
-	// Prepare an input string as body.
-	var input = "{"
-	input += ("\"serviceId\": \"" + serviceID + "\", ")
-	input += ("\"testEndpoint\": \"" + testEndpoint + "\", ")
-	input += ("\"runnerType\": \"" + runnerType + "\", ")
-	input += ("\"timeout\":  " + strconv.FormatInt(timeout, 10))
-	if len(secretName) > 0 {
-		input += (", \"secretName\": \"" + secretName + "\"")
+	// Prepare an input struct as body.
+	testReq := testRequest{
+		ServiceID:    serviceID,
+		TestEndpoint: testEndpoint,
+		RunnerType:   runnerType,
+		Timeout:      timeout,
+		SecretName:   secretName,
 	}
+
 	if len(filteredOperations) > 0 && ensureValidOperationsList(filteredOperations) {
-		input += (", \"filteredOperations\": " + filteredOperations)
+		testReq.FilteredOperations = json.RawMessage(filteredOperations)
 	}
 	if len(operationsHeaders) > 0 && ensureValidOperationsHeaders(operationsHeaders) {
-		input += (", \"operationsHeaders\": " + operationsHeaders)
+		testReq.OperationsHeaders = json.RawMessage(operationsHeaders)
 	}
 	if len(oAuth2Context) > 0 && ensureValidOAuth2Context(oAuth2Context) {
-		input += (", \"oAuth2Context\": " + oAuth2Context)
+		testReq.OAuth2Context = json.RawMessage(oAuth2Context)
 	}
 
-	input += "}"
+	input, err := json.Marshal(testReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal test request: %w", err)
+	}
 
-	req, err := http.NewRequest("POST", u.String(), strings.NewReader(input))
+	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(input))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Description
Looking through pkg/connectors and it still appeared that CreateTestResult was manually creating the test result using string concatenation to build the JSON. It was a bit of a chore to read and I'm not sure why we needed to add more fields later on, but I replaced it with a proper testRequest struct and json.Marshal.

I used json.We don't need to convert those optional "flags" (like filteredOperations) to JSON because they are already JSON strings from the CLI. Don't worry, I'm not about to unmarshal them and then put them back in the payload, but this way we are able to use omitempty properly.

Also found a typo in the main entry point: NewCommad -> NewCommand. I can't tell if it was by design or not, but I could not find it in any other place than main.go, so I just fixed it.


### Related issue(s) : #388 

Implementation Summary
Introduced a new struct called internal testRequest into microcks_client.go.
Replaced manual concatenation of strings in CreateTestResult with json.Marshal.
Changed the name of NewCommad to NewCommand in file cmd/cmd.go and main.go.
How I tested this
Rebuilt locally to ensure that the rename didn't cause any problems.
Tested JSON output for omitempty, which seems to work for secretName.
No new test case created for this because it is largely a refactoring of existing behavior, but the existing client tests appear happy.