### PR TITLE
fix(test): replace os.Args guard with cobra.ExactArgs(3) to prevent panic

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -42,35 +42,18 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 	)
 	var testCmd = &cobra.Command{
 
-		Use:   "test",
+		Use:   "test <apiName:apiVersion> <testEndpoint> <runner>",
 		Short: "Run tests on Microcks",
 		Long:  `Run tests on Microcks`,
+		Args:  cobra.ExactArgs(3),
 		Run: func(cmd *cobra.Command, args []string) {
-			// Parse subcommand args first.
-			if len(os.Args) < 4 {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
-				os.Exit(1)
-			}
 
 			serviceRef := args[0]
 			testEndpoint := args[1]
 			runnerType := args[2]
 
-			// Validate presence and values of args.
-			if len(serviceRef) == 0 || strings.HasPrefix(serviceRef, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
-				os.Exit(1)
-			}
-			if len(testEndpoint) == 0 || strings.HasPrefix(testEndpoint, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
-				os.Exit(1)
-			}
-			if len(runnerType) == 0 || strings.HasPrefix(runnerType, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
-				os.Exit(1)
-			}
-			if _, validChoice := runnerChoices[runnerType]; !validChoice {
-				fmt.Println("<runner> should be one of: HTTP, SOAP, SOAP_UI, POSTMAN, OPEN_API_SCHEMA, ASYNC_API_SCHEMA, GRPC_PROTOBUF, GRAPHQL_SCHEMA")
+			if _, ok := runnerChoices[runnerType]; !ok {
+				fmt.Println("<runner> should be one of: HTTP, SOAP_HTTP, SOAP_UI, POSTMAN, OPEN_API_SCHEMA, ASYNC_API_SCHEMA, GRPC_PROTOBUF, GRAPHQL_SCHEMA")
 				os.Exit(1)
 			}
 
@@ -169,7 +152,6 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				serverAddr = ctx.Server.Server
 			}
 
-			var testResultID string
 			testResultID, err := mc.CreateTestResult(serviceRef, testEndpoint, runnerType, secretName, waitForMilliseconds, filteredOperations, operationsHeaders, oAuth2Context)
 			if err != nil {
 				fmt.Printf("Got error when invoking Microcks client creating Test: %s", err)

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const missingTestArgsMessage = "accepts 3 arg(s), received 2"
+
+func TestTestCommandMissingRunnerWithGlobalFlagsDoesNotPanic(t *testing.T) {
+	if os.Getenv("MICROCKS_CLI_TEST_MISSING_RUNNER") == "1" {
+		os.Args = []string{
+			os.Args[0],
+			"test",
+			"--microcksURL=http://localhost:8080",
+			"--keycloakClientId=foo",
+			"--keycloakClientSecret=bar",
+			"MyAPI:1.0",
+			"http://localhost:3000",
+		}
+
+		err := NewCommad().Execute()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestTestCommandMissingRunnerWithGlobalFlagsDoesNotPanic")
+	cmd.Env = append(os.Environ(), "MICROCKS_CLI_TEST_MISSING_RUNNER=1")
+
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err)
+
+	exitError, ok := err.(*exec.ExitError)
+	require.True(t, ok)
+	assert.Equal(t, 1, exitError.ExitCode())
+	assert.Contains(t, string(output), missingTestArgsMessage)
+	assert.NotContains(t, string(output), "panic:") // core regression guard: must never crash with a stack trace
+}


### PR DESCRIPTION
## Summary

Fixes #390

The `test` command was guarding positional argument count with `len(os.Args) < 4`. This check includes global persistent flags (`--microcksURL`, `--keycloakClientId`, `--keycloakClientSecret`) in the count. When the command is invoked with global flags but the `<runner>` argument is omitted - the standard CI invocation pattern shown in the README - `os.Args` has enough elements to pass the guard, but Cobra's `args` slice (flags stripped) has only 2 elements. `args[2]` then causes a **runtime panic** with a stack trace instead of a clean error message.

## Changes

- **`cmd/test.go`**: Use `cobra.ExactArgs(3)` on the command definition (idiomatic Cobra). The framework validates arg count and prints usage before `Run` is invoked - no manual guard needed.
- - **`cmd/test.go`**: Update `Use` field to `"test <apiName:apiVersion> <testEndpoint> <runner>"` so `--help` output shows the expected signature.
- - **`cmd/test.go`**: Remove three now-dead `strings.HasPrefix(x, "-")` guards - Cobra strips all flags before passing `args` to `Run`, so none of those conditions can ever be true.
- - **`cmd/test.go`**: Remove redundant `var testResultID string` pre-declaration immediately shadowed by `:=`.
- - **`cmd/test.go`**: Fix runner validation error message: listed `SOAP` (not in `runnerChoices`) instead of `SOAP_HTTP`.
- - **`cmd/test_test.go`**: Add regression test that simulates the CI invocation pattern (global flags + missing runner) and asserts exit code 1 with no `panic:` in output.
## Before / After

**Before** (with global flags, missing `<runner>`):
```
goroutine 1 [running]:
runtime error: index out of range [2] with length 2
    cmd/test.go:57 +0x...
```

**After**:
```
Error: accepts 3 arg(s), received 2
Usage:
  microcks test <apiName:apiVersion> <testEndpoint> <runner> [flags]
```

## Testing

```bash
go test ./cmd/... -run TestTestCommandMissingRunnerWithGlobalFlagsDoesNotPanic -v
```
```
=== RUN   TestTestCommandMissingRunnerWithGlobalFlagsDoesNotPanic
--- PASS: TestTestCommandMissingRunnerWithGlobalFlagsDoesNotPanic (0.01s)
PASS
```
