### PR TITLE
fix: continue importing remaining artifacts on failure

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -114,6 +114,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 					return
 				}
 			}
+			var hasErrors bool
 
 			// Handle multiple specification files separated by comma.
 			sepSpecificationFiles := strings.Split(specificationFiles, ",")
@@ -132,16 +133,17 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				}
 
 				// Try uploading this artifact.
-				msg, err := mc.UploadArtifact(f, mainArtifact)
-				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client importing Artifact: %s", err)
-					os.Exit(1)
-				}
-				action := "discovered"
-				if !mainArtifact {
-					action = "completed"
-				}
-				fmt.Printf("Microcks has %s '%s'\n", action, msg)
+                msg, err := mc.UploadArtifact(f, mainArtifact)
+                if err != nil {
+                fmt.Printf("Failed to import '%s': %s\n", f, err)
+                hasErrors = true
+				continue
+			}
+			action := "discovered"
+			if !mainArtifact {
+				action = "completed"
+			}
+			fmt.Printf("Microcks has %s '%s'\n", action, msg)
 
 				// If watch flag is provided, update watch config.
 				if watch {
@@ -155,9 +157,8 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 					}
 
 					// Normalize file path to match the watcher fsnotify events format.
-					if strings.HasPrefix(f, "./") {
-						f = strings.TrimPrefix(f, "./")
-					}
+					
+					f = strings.TrimPrefix(f, "./")
 
 					// Upsert entry.
 					watchCfg.UpsertEntry(config.WatchEntry{
@@ -170,6 +171,9 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 					err = config.WriteLocalWatchConfig(*watchCfg, watchFile)
 					errors.CheckError(err)
 				}
+			}
+			if hasErrors {
+				os.Exit(1)
 			}
 
 			// Start watcher if --watch flag is provided.


### PR DESCRIPTION
## Summary
Fix early exit bug in import command when importing multiple artifacts.

## Problem
When running:
microcks import "file1.yaml,file2.yaml,file3.yaml"

If file2.yaml fails, the command immediately exits and file3.yaml 
is never imported. User has no visibility into which files succeeded.

## Fix
- Collect errors instead of exiting immediately on first failure
- Attempt all artifacts regardless of individual failures  
- Exit with code 1 only if any artifact failed

## Example output after fix
Failed to import 'file2.yaml': connection refused
Microcks has discovered 'file1.yaml'
Microcks has discovered 'file3.yaml'

## Files changed
- cmd/import.go — replaced os.Exit(1) with error collection and continue

Closes #393