### PR TITLE
docs: add --output-format flag to test command documentation

### DIFF
--- a/documentation/cmd/test.md
+++ b/documentation/cmd/test.md
@@ -34,7 +34,7 @@ One of:
 | `--filteredOperations` | Comma-separated list of operations to test                                          |
 | `--operationsHeaders`  | Custom headers for operations as JSON string                                        |
 | `--oAuth2Context`      | OAuth2 client context as JSON string                                                |
-
+| `--output-format`      | Output format for test results. Supported: `plain` (default), `github-actions`     |
 
 ### Options Inherited from Parent Commands
 | Flag                     | Description                                 |


### PR DESCRIPTION
## Summary
Added missing --output-format flag to test command documentation.

## Problem
The --output-format flag was added to the test command but was 
never documented in documentation/cmd/test.md. Users had no way 
to discover this flag from the official docs.

## Fix
Added --output-format flag to the Options table with supported 
values: plain (default) and github-actions.

## Files changed
- documentation/cmd/test.md — added --output-format flag entry

Closes #397