### PR TITLE
Replace unhandled panics with proper error returns in microcks_client

### DIFF
--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -151,7 +151,7 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 
 		u, err := url.Parse(apiURL)
 		if err != nil {
-			panic(err)
+			return nil, fmt.Errorf("failed to parse API URL: %w", err)
 		}
 		c.APIURL = u
 
@@ -239,12 +239,12 @@ func (c *microcksClient) GetKeycloakURL() (string, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to read keycloak config response body: %w", err)
 	}
 
 	var configResp map[string]interface{}
 	if err := json.Unmarshal(body, &configResp); err != nil {
-		panic(err)
+		return "", fmt.Errorf("failed to parse keycloak config response: %w", err)
 	}
 
 	// Retrieve auth server url and realm name.
@@ -381,15 +381,18 @@ func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string,
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to read create test response body: %w", err)
 	}
 
 	var createTestResp map[string]interface{}
 	if err := json.Unmarshal(body, &createTestResp); err != nil {
-		panic(err)
+		return "", fmt.Errorf("failed to parse create test response: %w", err)
 	}
 
-	testID := createTestResp["id"].(string)
+	testID, ok := createTestResp["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("invalid response format: missing or non-string id")
+	}
 	return testID, err
 }
 
@@ -420,7 +423,7 @@ func (c *microcksClient) GetTestResult(testResultID string) (*TestResultSummary,
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return nil, fmt.Errorf("failed to read test result response body: %w", err)
 	}
 
 	result := TestResultSummary{}
@@ -553,7 +556,7 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to read upload artifact response body: %w", err)
 	}
 
 	// Raise exception if not created.


### PR DESCRIPTION
 in pkg/connectors/microcks_client.go, I noticed that several methods were using panic(err) when reading HTTP response bodies or unmarshaling JSON. If the Microcks server returns a bad response or there's a network blip, this would completely crash the CLI.

I went through and swapped out all those panic calls for proper fmt.Errorf returns in the functions that already have an error return type. this way the errors bubble up properly and we can handle them gracefully instead of just dying on the spot.

Implementation details
Removed panic(err) in NewClient, GetKeycloakURL, CreateTestResult, GetTestResult, and UploadArtifact.
Replaced them with context-wrapped errors (e.g. fmt.Errorf("failed to read test result response body: %w", err)).
In CreateTestResult, I also added a safe type assertion check (testID, ok := createTestResp["id"].(string)) so it doesn't panic if the id field happens to be missing or isn't a string.

Testing
Built the CLI locally.
Intentionally caused some network failures/invalid JSON responses and verified that the CLI now prints a clean error message and exits normally instead of throwing a stack trace panic.

### Related issue(s) #403 

