### PR TITLE
fix(login): remove unconditional logging of OAuth2 access and refresh tokens

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -293,8 +293,6 @@ func oauth2login(
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 	_ = srv.Shutdown(ctx)
-	log.Printf("Token: %s\n", tokenString)
-	log.Printf("Refresh Token: %s\n", refreshToken)
 	return tokenString, refreshToken
 }
 


### PR DESCRIPTION
 Summary
Removes two `log.Printf` calls in `cmd/login.go` that unconditionally printed the OAuth2 access token and refresh token to stderr on every SSO login — regardless of whether `--verbose` was set.

Problem
```go
// Before — leaks credentials to stderr unconditionally
log.Printf("Token: %s\n", tokenString)
log.Printf("Refresh Token: %s\n", refreshToken)
```
Any CI/CD pipeline or log aggregation system capturing stderr silently records long-lived credentials in plaintext. Refresh tokens are especially dangerous — they allow obtaining new access tokens without user interaction.

All other sensitive output in this codebase is gated behind config.Verbose / config.DumpRequestIfRequired. These two lines were the only exception — leftover debug statements.

Changes:
cmd/login.go: removed 2 lines — the unconditional token log statements
The fmt.Printf("Authentication successful\n") immediately above already confirms success without exposing any credential
Testing
go build ./...  # clean
go test ./...   # all pass
go vet ./...    # clean
Manual: SSO login flow no longer prints token values to stderr. Behavior otherwise unchanged.

Fixes : #345 
