### PR TITLE
fix(context): guard nil local config before context switch

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -45,6 +45,9 @@ microcks context http://localhost:8080 --delete`,
 				printMicrocksContexts(configPath)
 				return
 			}
+			if localCfg == nil {
+				log.Fatalf("No contexts defined in %s", configPath)
+			}
 
 			ctxName := args[0]
 			if localCfg.CurrentContext == ctxName {
@@ -122,3 +125,4 @@ func printMicrocksContexts(configPath string) {
 		errors.CheckError(err)
 	}
 }
+


### PR DESCRIPTION
### Description

This PR fixes a crash path in the `microcks context` command when no local config exists yet.

#### Problem
When running `microcks context <context-name>` on a fresh machine (or after config cleanup), `localCfg` can be `nil`.  
The command dereferences `localCfg` (`localCfg.CurrentContext`) without a nil guard, which can lead to a nil pointer panic instead of a user-friendly message.

#### Changes
- Added a defensive `localCfg == nil` check in `cmd/context.go` before first dereference in the context-switch flow.
- Preserved current behavior for:
  - `microcks context` (no args): still lists contexts / prints existing output path.
  - `microcks context --delete ...`: unchanged.

#### Result
- No panic when config is missing.
- Users now get a clear, deterministic error path instead of a runtime crash.