### PR TITLE
fix(config): return pointers to slice elements in LocalConfig getters

### DIFF
--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -240,9 +240,7 @@ func (l *LocalConfig) RemoveToken(serverName string) bool {
 
 // GetUser retrieves a user by name.
 func (l *LocalConfig) GetUser(name string) (*User, error) {
-	for _, u := range l.Users {
-		if u.Name == name {
-			return &u, nil
+	for i := range l.Users {`r`n`t`tif l.Users[i].Name == name {`r`n`t`t`treturn &l.Users[i], nil
 		}
 	}
 	return nil, fmt.Errorf("User '%s' undefined", name)
@@ -272,9 +270,7 @@ func (l *LocalConfig) RemoveUser(serverName string) bool {
 }
 
 func (l *LocalConfig) GetServer(name string) (*Server, error) {
-	for _, s := range l.Servers {
-		if s.Server == name {
-			return &s, nil
+	for i := range l.Servers {`r`n`t`tif l.Servers[i].Server == name {`r`n`t`t`treturn &l.Servers[i], nil
 		}
 	}
 	return nil, fmt.Errorf("Server '%s' undefined", name)
@@ -302,9 +298,7 @@ func (l *LocalConfig) RemoveServer(serverName string) bool {
 }
 
 func (l *LocalConfig) GetInstance(name string) (*Instance, error) {
-	for _, i := range l.Instances {
-		if i.Name == name {
-			return &i, nil
+	for i := range l.Instances {`r`n`t`tif l.Instances[i].Name == name {`r`n`t`t`treturn &l.Instances[i], nil
 		}
 	}
 	return nil, fmt.Errorf("Instance '%s' undefined", name)
@@ -339,9 +333,7 @@ func (l *LocalConfig) IsEmpty() bool {
 }
 
 func (l *LocalConfig) GetAuth(server string) (*Auth, error) {
-	for _, a := range l.Auths {
-		if a.Server == server {
-			return &a, nil
+	for i := range l.Auths {`r`n`t`tif l.Auths[i].Server == server {`r`n`t`t`treturn &l.Auths[i], nil
 		}
 	}
 
@@ -413,3 +405,5 @@ func WriteLocalWatchConfig(config WatchConfig, cfgPath string) error {
 	}
 	return configUtil.MarshalLocalYAMLFile(cfgPath, &config)
 }
+
+

--- a/pkg/config/localconfig_test.go
+++ b/pkg/config/localconfig_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestGetUserReturnsReferenceToStoredEntry(t *testing.T) {
+    cfg := LocalConfig{
+        Users: []User{
+            {Name: "http://localhost:8080", AuthToken: "old-token"},
+        },
+    }
+
+    user, err := cfg.GetUser("http://localhost:8080")
+    require.NoError(t, err)
+
+    user.AuthToken = "new-token"
+    assert.Equal(t, "new-token", cfg.Users[0].AuthToken)
+}
+
+func TestGetServerReturnsReferenceToStoredEntry(t *testing.T) {
+    cfg := LocalConfig{
+        Servers: []Server{
+            {Server: "http://localhost:8080", KeycloakEnable: true},
+        },
+    }
+
+    server, err := cfg.GetServer("http://localhost:8080")
+    require.NoError(t, err)
+
+    server.KeycloakEnable = false
+    assert.False(t, cfg.Servers[0].KeycloakEnable)
+}
+
+func TestGetInstanceReturnsReferenceToStoredEntry(t *testing.T) {
+    cfg := LocalConfig{
+        Instances: []Instance{
+            {Name: "microcks", Status: "Exited"},
+        },
+    }
+
+    instance, err := cfg.GetInstance("microcks")
+    require.NoError(t, err)
+
+    instance.Status = "Running"
+    assert.Equal(t, "Running", cfg.Instances[0].Status)
+}
+
+func TestGetAuthReturnsReferenceToStoredEntry(t *testing.T) {
+    cfg := LocalConfig{
+        Auths: []Auth{
+            {Server: "http://localhost:8080", ClientId: "id-a"},
+        },
+    }
+
+    auth, err := cfg.GetAuth("http://localhost:8080")
+    require.NoError(t, err)
+
+    auth.ClientId = "id-b"
+    assert.Equal(t, "id-b", cfg.Auths[0].ClientId)
+}


### PR DESCRIPTION
### Description

This PR fixes pointer semantics in `LocalConfig` getters to ensure returned pointers reference real backing slice elements.

#### Problem
The getters used range-value iteration patterns like:
- `for _, u := range l.Users { return &u }`

This returns the address of a loop variable copy, not the original slice element.  
As a result, callers mutating through returned pointers may silently modify detached copies, causing subtle state bugs.

#### Changes
Updated all affected getters in `pkg/config/localconfig.go` to index-based iteration:
- `GetUser`
- `GetServer`
- `GetInstance`
- `GetAuth`

Pattern changed to:
- `for i := range l.Users { return &l.Users[i] }` (and equivalent for other slices)

#### Tests
Added `pkg/config/localconfig_test.go` with regression coverage that verifies pointer-backed mutation for all four getters:
- mutate field through returned pointer
- assert corresponding slice element is updated

#### Result
- Getter pointers now correctly point into `LocalConfig` slices.
- Prevents stale-copy mutation bugs and makes behavior consistent with caller expectations.