### PR TITLE
fix(errors): honor caller exit code in Fatal

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -26,6 +26,8 @@ func CheckError(err error) {
 
 // Fatal is a wrapper for log.Fatal() to exit with custom code
 func Fatal(exitcode int, args ...interface{}) {
-	log.Fatal(args...)
+	log.Println(args...)
 	os.Exit(exitcode)
 }
+
+


### PR DESCRIPTION
### Description

This PR fixes exit-code handling in `pkg/errors.Fatal` so command-level callers can reliably control process exit status.

#### Problem
`Fatal(exitcode, args...)` currently uses `log.Fatal(args...)`, which already exits with code `1`.  
That means the subsequent `os.Exit(exitcode)` is effectively unreachable for non-1 exit semantics, and caller-provided exit codes are not honored.

#### Changes
In `pkg/errors/error.go`:
- Replaced `log.Fatal(args...)` with `log.Println(args...)`
- Kept explicit `os.Exit(exitcode)`

#### Result
- Error is still logged.
- Process exits using the caller-provided code, restoring expected CLI behavior for scripts/CI that rely on specific status codes.