### PR TITLE
docs: remove duplicate Installation heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ microcks [command] [flags]
 | `--microcksURL`          | Microcks API URL                            |
 
 
-## Installation
+
 
 ### Building from Source
+
 To build the CLI locally:
 
 ```bash


### PR DESCRIPTION
### Description
- Removed the duplicate `## Installation` heading that appeared before the "Building from Source" section
- The `### Building from Source` heading is self-explanatory and does not need a duplicate parent heading

### How to verify
Open README.md and confirm there is only one `## Installation` section