### PR TITLE
Fix/error output stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ microcks [command] [flags]
 | `--microcksURL`          | Microcks API URL                            |
 
 
-## Installation
+
 
 ### Building from Source
+
 To build the CLI locally:
 
 ```bash

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -39,7 +39,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 		Run: func(cmd *cobra.Command, args []string) {
 			// Parse subcommand args first.
 			if len(args) == 0 {
-				fmt.Println("import command require <specificationFile1[:primary],specificationFile2[:primary]> args")
+				fmt.Fprintln(os.Stderr, "import command require <specificationFile1[:primary],specificationFile2[:primary]> args")
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
@@ -54,7 +54,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 			// Read local config file in case we need some context info.
 			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 			if err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				return
 			}
 
@@ -67,7 +67,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
+					fmt.Fprintf(os.Stderr, "Got error when invoking Microcks client retrieving config: %s", err)
 					os.Exit(1)
 				}
 
@@ -78,7 +78,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloak client: %s", err)
+						fmt.Fprintf(os.Stderr, "Got error when invoking Keycloak client: %s", err)
 						os.Exit(1)
 					}
 					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
@@ -100,7 +100,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 			} else {
 				// Create client from config file and using the current or provided context.
 				if localConfig == nil {
-					fmt.Println("Please login to perform operation...")
+					fmt.Fprintln(os.Stderr, "Please login to perform operation...")
 					return
 				}
 
@@ -110,7 +110,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
-					fmt.Printf("error %v", err)
+					fmt.Fprintf(os.Stderr, "error %v", err)
 					return
 				}
 			}
@@ -134,14 +134,14 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				// Try uploading this artifact.
 				msg, err := mc.UploadArtifact(f, mainArtifact)
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client importing Artifact: %s", err)
+					fmt.Fprintf(os.Stderr, "Got error when invoking Microcks client importing Artifact: %s", err)
 					os.Exit(1)
 				}
 				action := "discovered"
 				if !mainArtifact {
 					action = "completed"
 				}
-				fmt.Printf("Microcks has %s '%s'\n", action, msg)
+				fmt.Fprintf(os.Stderr, "Microcks has %s '%s'\n", action, msg)
 
 				// If watch flag is provided, update watch config.
 				if watch {
@@ -180,7 +180,7 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				wm, err := watcher.NewWatchManger(watchFile)
 				errors.CheckError(err)
 
-				fmt.Println("Watch mode enabled - microcks-watcher started...")
+				fmt.Fprintln(os.Stderr, "Watch mode enabled - microcks-watcher started...")
 				wm.Run()
 			}
 		},

--- a/cmd/importDir.go
+++ b/cmd/importDir.go
@@ -130,12 +130,12 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 			localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 			if err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				return
 			}
 
 			if localConfig == nil {
-				fmt.Println("Please login to perform operation...")
+				fmt.Fprintln(os.Stderr, "Please login to perform operation...")
 				return
 			}
 
@@ -146,7 +146,7 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			// Create client
 			mc, err := connectors.NewClient(*globalClientOpts)
 			if err != nil {
-				fmt.Printf("error %v", err)
+				fmt.Fprintf(os.Stderr, "error %v", err)
 				return
 			}
 
@@ -162,41 +162,41 @@ func NewImportDirCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 			result, err := ImportDirectory(mc, fs, dirPath, importConfig)
 			if err != nil {
 				if validationErr, ok := err.(*ValidationError); ok {
-					fmt.Println(validationErr.Message)
-					return
+					fmt.Fprintln(os.Stderr, validationErr.Message)
+					os.Exit(1)
 				}
-				fmt.Printf("Error: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}
 
 			// Display results
 			if verbose {
-				fmt.Printf("Found %d specification files to import...\n", result.TotalFiles)
+				fmt.Fprintf(os.Stderr, "Found %d specification files to import...\n", result.TotalFiles)
 				for i, file := range result.SuccessFiles {
-					fmt.Printf("[%d/%d] ✓ Imported: %s\n", i+1, result.TotalFiles, file)
+					fmt.Fprintf(os.Stderr, "[%d/%d] ✓ Imported: %s\n", i+1, result.TotalFiles, file)
 				}
 				for i, file := range result.FailedFiles {
 					errorMsg := "Unknown error"
 					if i < len(result.Errors) {
 						errorMsg = result.Errors[i]
 					}
-					fmt.Printf("✗ Failed: %s - %s\n", file, errorMsg)
+					fmt.Fprintf(os.Stderr, "✗ Failed: %s - %s\n", file, errorMsg)
 				}
 			} else {
-				fmt.Println("\nImport results:")
+				fmt.Fprintln(os.Stderr, "\nImport results:")
 				for _, file := range result.SuccessFiles {
-					fmt.Printf("✓ Imported: %s\n", file)
+					fmt.Fprintf(os.Stderr, "✓ Imported: %s\n", file)
 				}
 				for i, file := range result.FailedFiles {
 					errorMsg := "Unknown error"
 					if i < len(result.Errors) {
 						errorMsg = result.Errors[i]
 					}
-					fmt.Printf("✗ Failed: %s - %s\n", file, errorMsg)
+					fmt.Fprintf(os.Stderr, "✗ Failed: %s - %s\n", file, errorMsg)
 				}
 			}
 
-			fmt.Printf("\nImport completed: %d/%d files imported successfully\n", result.SuccessCount, result.TotalFiles)
+			fmt.Fprintf(os.Stderr, "\nImport completed: %d/%d files imported successfully\n", result.SuccessCount, result.TotalFiles)
 		},
 	}
 
@@ -242,7 +242,7 @@ func ImportDirectory(client MicrocksClient, fs FileSystem, dirPath string, confi
 			if !fileType.IsPrimary {
 				action = "completed"
 			}
-			fmt.Printf("Microcks has %s '%s'\n", action, msg)
+			fmt.Fprintf(os.Stderr, "Microcks has %s '%s'\n", action, msg)
 		}
 
 		result.SuccessCount++

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -35,7 +35,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 		Run: func(cmd *cobra.Command, args []string) {
 			// Parse subcommand args first.
 			if len(args) == 0 {
-				fmt.Println("import-url command require <specificationFile1URL[:primary],specificationFile2URL[:primary]> args")
+				fmt.Fprintln(os.Stderr, "import-url command require <specificationFile1URL[:primary],specificationFile2URL[:primary]> args")
 				os.Exit(1)
 			}
 
@@ -53,7 +53,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
+					fmt.Fprintf(os.Stderr, "Got error when invoking Microcks client retrieving config: %s", err)
 					os.Exit(1)
 				}
 
@@ -64,7 +64,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloak client: %s", err)
+						fmt.Fprintf(os.Stderr, "Got error when invoking Keycloak client: %s", err)
 						os.Exit(1)
 					}
 					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -48,7 +48,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			// Parse subcommand args first.
 			if len(os.Args) < 4 {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
+				fmt.Fprintln(os.Stderr, "test command require <apiName:apiVersion> <testEndpoint> <runner> args")
 				os.Exit(1)
 			}
 
@@ -58,25 +58,25 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 			// Validate presence and values of args.
 			if len(serviceRef) == 0 || strings.HasPrefix(serviceRef, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
+			fmt.Fprintln(os.Stderr, "test command require <apiName:apiVersion> <testEndpoint> <runner> args")
 				os.Exit(1)
 			}
 			if len(testEndpoint) == 0 || strings.HasPrefix(testEndpoint, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
+			fmt.Fprintln(os.Stderr, "test command require <apiName:apiVersion> <testEndpoint> <runner> args")
 				os.Exit(1)
 			}
 			if len(runnerType) == 0 || strings.HasPrefix(runnerType, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
+				fmt.Fprintln(os.Stderr, "test command require <apiName:apiVersion> <testEndpoint> <runner> args")
 				os.Exit(1)
 			}
 			if _, validChoice := runnerChoices[runnerType]; !validChoice {
-				fmt.Println("<runner> should be one of: HTTP, SOAP_HTTP, SOAP_UI, POSTMAN, OPEN_API_SCHEMA, ASYNC_API_SCHEMA, GRPC_PROTOBUF, GRAPHQL_SCHEMA")
+				fmt.Fprintln(os.Stderr, "<runner> should be one of: HTTP, SOAP_HTTP, SOAP_UI, POSTMAN, OPEN_API_SCHEMA, ASYNC_API_SCHEMA, GRPC_PROTOBUF, GRAPHQL_SCHEMA")
 				os.Exit(1)
 			}
 
 			// Validate presence and values of flags.
 			if !strings.HasSuffix(waitFor, "milli") && !strings.HasSuffix(waitFor, "sec") && !strings.HasSuffix(waitFor, "min") {
-				fmt.Println("--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)")
+				fmt.Fprintln(os.Stderr, "--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)")	
 				os.Exit(1)
 			}
 
@@ -90,21 +90,21 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			if strings.HasSuffix(waitFor, "milli") {
 				n, err := strconv.ParseInt(waitFor[:len(waitFor)-5], 0, 64)
 				if err != nil {
-					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
+					fmt.Fprintf(os.Stderr, "--waitFor value %q is not a valid number\n", waitFor)
 					os.Exit(1)
 				}
 				waitForMilliseconds = n
 			} else if strings.HasSuffix(waitFor, "sec") {
 				n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
 				if err != nil {
-					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
+					fmt.Fprintf(os.Stderr, "--waitFor value %q is not a valid number\n", waitFor)
 					os.Exit(1)
 				}
 				waitForMilliseconds = n * 1000
 			} else if strings.HasSuffix(waitFor, "min") {
 				n, err := strconv.ParseInt(waitFor[:len(waitFor)-3], 0, 64)
 				if err != nil {
-					fmt.Printf("--waitFor value %q is not a valid number\n", waitFor)
+					fmt.Fprintf(os.Stderr, "--waitFor value %q is not a valid number\n", waitFor)
 					os.Exit(1)
 				}
 				waitForMilliseconds = n * 60 * 1000
@@ -121,7 +121,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 				keycloakURL, err := mc.GetKeycloakURL()
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client retrieving config: %s", err)
+					fmt.Fprintf(os.Stderr, "Got error when invoking Microcks client retrieving config: %s", err)
 					os.Exit(1)
 				}
 
@@ -132,7 +132,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 					oauthToken, err = kc.ConnectAndGetToken()
 					if err != nil {
-						fmt.Printf("Got error when invoking Keycloak client: %s", err)
+						fmt.Fprintf(os.Stderr, "Got error when invoking Keycloak client: %s", err)
 						os.Exit(1)
 					}
 					//fmt.Printf("Retrieve OAuthToken: %s", oauthToken)
@@ -144,12 +144,12 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			} else {
 				localConfig, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
 				if err != nil {
-					fmt.Println(err)
+					fmt.Fprintln(os.Stderr, err)
 					return
 				}
 
 				if localConfig == nil {
-					fmt.Println("Please login to perform operation...")
+					fmt.Fprintln(os.Stderr, "Please login to perform operation...")
 					return
 				}
 
@@ -159,7 +159,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 				mc, err = connectors.NewClient(*globalClientOpts)
 				if err != nil {
-					fmt.Printf("error %v", err)
+					fmt.Fprintf(os.Stderr, "error %v", err)
 					return
 				}
 
@@ -172,7 +172,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			var testResultID string
 			testResultID, err := mc.CreateTestResult(serviceRef, testEndpoint, runnerType, secretName, waitForMilliseconds, filteredOperations, operationsHeaders, oAuth2Context)
 			if err != nil {
-				fmt.Printf("Got error when invoking Microcks client creating Test: %s", err)
+				fmt.Fprintf(os.Stderr, "Got error when invoking Microcks client creating Test: %s", err)
 				os.Exit(1)
 			}
 			//fmt.Printf("Retrieve TestResult ID: %s", testResultID)
@@ -188,22 +188,22 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			for nowInMilliseconds() < future {
 				testResultSummary, err := mc.GetTestResult(testResultID)
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client check TestResult: %s", err)
+					fmt.Fprintf(os.Stderr, "Got error when invoking Microcks client check TestResult: %s", err)
 					os.Exit(1)
 				}
 				success = testResultSummary.Success
 				inProgress := testResultSummary.InProgress
-				fmt.Printf("MicrocksClient got status for test \"%s\" - success: %s, inProgress: %s \n", testResultID, fmt.Sprint(success), fmt.Sprint(inProgress))
+				fmt.Fprintf(os.Stderr, "MicrocksClient got status for test \"%s\" - success: %s, inProgress: %s \n", testResultID, fmt.Sprint(success), fmt.Sprint(inProgress))
 
 				if !inProgress {
 					break
 				}
 
-				fmt.Println("MicrocksTester waiting for 2 seconds before checking again or exiting.")
+					fmt.Fprintln(os.Stderr, "MicrocksTester waiting for 2 seconds before checking again or exiting.")
 				time.Sleep(2 * time.Second)
 			}
 
-			fmt.Printf("Full TestResult details are available here: %s/#/tests/%s \n", serverAddr, testResultID)
+				fmt.Fprintf(os.Stderr, "Full TestResult details are available here: %s/#/tests/%s \n", serverAddr, testResultID)
 
 			if !success {
 				os.Exit(1)


### PR DESCRIPTION
Fixes #413
## What does this PR do?
Error messages in CLI commands were being written to `stdout` instead of `stderr`. This is incorrect Unix behavior — errors should go to `stderr` so that scripts and CI/CD pipelines can properly separate program output from error messages.

## Changes made
- `cmd/test.go` —  error messages moved to `stderr`
- `cmd/import.go` —  error messages moved to `stderr`
- `cmd/importDir.go` —  error messages moved to `stderr`
- `cmd/importURL.go` —  error messages moved to `stderr`

## Why this matters
When Microcks CLI is used in CI/CD pipelines, tools like `grep`, `awk`, or log parsers pipe `stdout` and `stderr` separately. Printing errors to `stdout` pollutes the output stream and breaks scripting workflows.

## How to verify
Run any command with missing or invalid args and redirect stdout to /dev/null:
```bash
microcks test 2>/dev/null
# Error message should NOT appear (it goes to stderr now)

microcks test 2>&1 1>/dev/null  
# Error message SHOULD appear here
```

Relates to improving CLI robustness for CI/CD usage.