### PR TITLE
Fix local test config path and quote build-local output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ HOST_ARCH=$(shell go env GOARCH)
 
 .PHONY: build-local
 build-local:
-	go build -o ${DIST_DIR}/${BIN_NAME}
+	@mkdir -p "${DIST_DIR}"
+	go build -o "${DIST_DIR}/${BIN_NAME}"
 
 .PHONY: clean
 clean:

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/microcks/microcks-cli/pkg/config"
@@ -36,9 +37,9 @@ users:
   auth-token: ""
   refresh-token: ""`
 
-const testConfigFilePath = "./testdata/local.config"
-
 func TestDeleteContext(t *testing.T) {
+	testConfigFilePath := filepath.Join(t.TempDir(), "local.config")
+
 	//write the test config file
 	err := os.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
 	require.NoError(t, err)


### PR DESCRIPTION
This fixes two small issues that show up when working on the CLI locally.

The first is in `cmd/context_test.go`. `TestDeleteContext` was writing to `./testdata/local.config`, which fails when that directory is missing. This change switches the test to `t.TempDir()` so it stays self-contained and does not depend on repository state.

The second is in `make build-local`. The build output path was not quoted, so it breaks when the checkout path contains spaces. This updates the target to create the output directory first and quote the `-o` path.

I used the following checks locally:

- `go test ./...`
- `make build-local`

Both pass from a checkout located in a path with spaces.
