### PR TITLE
Feat/improve test error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ microcks [command] [flags]
 | `--microcksURL`          | Microcks API URL                            |
 
 
-## Installation
+
 
 ### Building from Source
+
 To build the CLI locally:
 
 ```bash

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -58,15 +58,15 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
 			// Validate presence and values of args.
 			if len(serviceRef) == 0 || strings.HasPrefix(serviceRef, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
+				fmt.Fprintln(os.Stderr, "missing required argument: <apiName:apiVersion> (e.g. 'my-api:1.0')")
 				os.Exit(1)
 			}
 			if len(testEndpoint) == 0 || strings.HasPrefix(testEndpoint, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
+				fmt.Fprintln(os.Stderr, "missing required argument: <testEndpoint> (e.g. 'http://localhost:8080/api')")
 				os.Exit(1)
 			}
 			if len(runnerType) == 0 || strings.HasPrefix(runnerType, "-") {
-				fmt.Println("test command require <apiName:apiVersion> <testEndpoint> <runner> args")
+				fmt.Fprintln(os.Stderr, "missing required argument: <runner> (e.g. 'HTTP', 'POSTMAN', 'OPEN_API_SCHEMA')")
 				os.Exit(1)
 			}
 			if _, validChoice := runnerChoices[runnerType]; !validChoice {


### PR DESCRIPTION
Fixes #412 

## What does this PR do?
The `test` command was printing the same generic error message 
for three different missing arguments, giving users no indication 
of which specific argument was missing or what format it expects.

## Before this fix
test command require apiName:apiVersion <testEndpoint> <runner> args
test command require apiName:apiVersion <testEndpoint> <runner> args
test command require apiName:apiVersion <testEndpoint> <runner> args

## After this fix
missing required argument: apiName:apiVersion (e.g. 'my-api:1.0')
missing required argument: <testEndpoint> (e.g. 'http://localhost:8080/api')
missing required argument: <runner> (e.g. 'HTTP', 'POSTMAN', 'OPEN_API_SCHEMA')

## Why this matters
Better error messages = faster debugging. Users immediately know 
exactly which argument is missing and what format is expected, 
without having to read the docs.

## How to verify
Run the test command with missing arguments:
```bash
microcks test
microcks test my-api:1.0
microcks test my-api:1.0 http://localhost:8080
```
Each should now show a specific, helpful error message.