### PR TITLE
fix: logout resolves named contexts

### DIFF
--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
-	"github.com/microcks/microcks-cli/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -29,29 +28,40 @@ microcks logout dev-context`,
 				os.Exit(1)
 			}
 
-			context := args[0]
-			localCfg, err := config.ReadLocalConfig(globalClientOpts.ConfigPath)
-			errors.CheckError(err)
-			if localCfg == nil {
-				log.Fatalf("Nothing to logout from")
-			}
-
-			// Remove authToken
-			ok := localCfg.RemoveToken(context)
-			if !ok {
-				log.Fatalf("Context %s does not exist", context)
-			}
-
-			err = config.ValidateLocalConfig(*localCfg)
+			target := args[0]
+			err := logoutContext(target, globalClientOpts.ConfigPath)
 			if err != nil {
-				log.Fatalf("Error in loging out: %s", err)
+				log.Fatal(err)
 			}
-			err = config.WriteLocalConfig(*localCfg, globalClientOpts.ConfigPath)
-			errors.CheckError(err)
-
-			fmt.Printf("Logged out from '%s'\n", context)
+			fmt.Printf("Logged out from '%s'\n", target)
 		},
 	}
 
 	return logoutCmd
+}
+
+func logoutContext(target, configPath string) error {
+	localCfg, err := config.ReadLocalConfig(configPath)
+	if err != nil {
+		return err
+	}
+	if localCfg == nil {
+		return fmt.Errorf("Nothing to logout from")
+	}
+
+	userName := target
+	if ctx, err := localCfg.ResolveContext(target); err == nil {
+		userName = ctx.User.Name
+	}
+
+	if ok := localCfg.RemoveToken(userName); !ok {
+		return fmt.Errorf("Context %s does not exist", target)
+	}
+
+	err = config.ValidateLocalConfig(*localCfg)
+	if err != nil {
+		return fmt.Errorf("Error in loging out: %s", err)
+	}
+
+	return config.WriteLocalConfig(*localCfg, configPath)
 }

--- a/cmd/logout_test.go
+++ b/cmd/logout_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/microcks/microcks-cli/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogoutContextResolvesNamedContextUser(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config")
+	server := "https://microcks.example"
+
+	localCfg := config.LocalConfig{
+		CurrentContext: "staging",
+		Contexts: []config.ContextRef{
+			{Name: "staging", Server: server, User: server},
+		},
+		Servers: []config.Server{
+			{Server: server, KeycloakEnable: true},
+		},
+		Users: []config.User{
+			{Name: server, AuthToken: "access-token", RefreshToken: "refresh-token"},
+		},
+	}
+	require.NoError(t, config.WriteLocalConfig(localCfg, configPath))
+
+	require.NoError(t, logoutContext("staging", configPath))
+
+	updated, err := config.ReadLocalConfig(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	user, err := updated.GetUser(server)
+	require.NoError(t, err)
+	require.Empty(t, user.AuthToken)
+	require.Empty(t, user.RefreshToken)
+}
+
+func TestLogoutContextStillAcceptsStoredUserName(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config")
+	server := "https://microcks.example"
+
+	localCfg := config.LocalConfig{
+		CurrentContext: "staging",
+		Contexts: []config.ContextRef{
+			{Name: "staging", Server: server, User: server},
+		},
+		Servers: []config.Server{
+			{Server: server, KeycloakEnable: true},
+		},
+		Users: []config.User{
+			{Name: server, AuthToken: "access-token", RefreshToken: "refresh-token"},
+		},
+	}
+	require.NoError(t, config.WriteLocalConfig(localCfg, configPath))
+
+	require.NoError(t, logoutContext(server, configPath))
+
+	updated, err := config.ReadLocalConfig(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	user, err := updated.GetUser(server)
+	require.NoError(t, err)
+	require.Empty(t, user.AuthToken)
+	require.Empty(t, user.RefreshToken)
+}


### PR DESCRIPTION
## Summary

Fixes #419.

`microcks logout` now resolves the provided argument as a Microcks context before clearing tokens. That makes the documented named-context flow work for logins created with `microcks login ... --name <context>`, while still preserving the old behavior of accepting the stored user/server name directly.

## Root cause

`login --name staging` stores the user under the server URL and stores `staging` only as the context name. `logout` passed the argument directly to `RemoveToken`, which searches users by name, so `microcks logout staging` could not find the token entry.

## Validation

- `go test ./cmd -run TestLogoutContext -count=1`
- `go test ./pkg/config ./pkg/connectors`
- `go vet ./cmd`

Note: `go test ./...` is still blocked by the existing `TestDeleteContext` fixture issue where `cmd/context_test.go` writes `./testdata/local.config` before creating `cmd/testdata`.
