### PR TITLE
fix: keep shared server config when deleting one of multiple contexts

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -72,12 +72,25 @@ func deleteContext(context, configPath string) error {
 	if localCfg == nil {
 		return fmt.Errorf("Nothing to logout from")
 	}
-	serverName, ok := localCfg.RemoveContext(context)
+	resolvedContext, err := localCfg.ResolveContext(context)
+	if err != nil {
+		return fmt.Errorf("Context %s does not exist", context)
+	}
+	_, ok := localCfg.RemoveContext(context)
 	if !ok {
 		return fmt.Errorf("Context %s does not exist", context)
 	}
-	_ = localCfg.RemoveUser(context)
-	_ = localCfg.RemoveServer(serverName)
+
+	if !localCfg.HasContextUsingUser(resolvedContext.User.Name) {
+		_ = localCfg.RemoveUser(resolvedContext.User.Name)
+	}
+	if !localCfg.HasContextUsingServer(resolvedContext.Server.Server) {
+		_ = localCfg.RemoveServer(resolvedContext.Server.Server)
+		_ = localCfg.RemoveAuth(resolvedContext.Server.Server)
+	}
+	if !localCfg.HasContextUsingInstance(resolvedContext.Instance.Name) {
+		_ = localCfg.RemoveInstance(resolvedContext.Instance.Name)
+	}
 
 	if localCfg.IsEmpty() {
 		err := localCfg.DeleteLocalConfig(configPath)

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/microcks/microcks-cli/pkg/config"
@@ -36,9 +37,41 @@ users:
   auth-token: ""
   refresh-token: ""`
 
-const testConfigFilePath = "./testdata/local.config"
+const sharedServerConfig = `current-context: dev
+contexts:
+- name: dev
+  server: http://localhost:8585
+  user: http://localhost:8585
+  instance: microcks
+- name: qa
+  server: http://localhost:8585
+  user: http://localhost:8585
+  instance: microcks
+servers:
+- name: microcks
+  server: http://localhost:8585
+  insecureTLS: true
+  keycloakEnable: false
+users:
+- name: http://localhost:8585
+  auth-token: ""
+  refresh-token: ""
+instances:
+- name: microcks
+  image: quay.io/microcks/microcks-uber:latest-native
+  status: Running
+  port: "8585"
+  containerID: abc123
+  autoRemove: false
+  driver: docker
+auths:
+- server: http://localhost:8585
+  clientid: ""
+  clientsecret: ""`
 
 func TestDeleteContext(t *testing.T) {
+	testConfigFilePath := filepath.Join(t.TempDir(), "local.config")
+
 	//write the test config file
 	err := os.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
 	require.NoError(t, err)
@@ -63,4 +96,33 @@ func TestDeleteContext(t *testing.T) {
 	require.NoError(t, err)
 	_, err = config.ReadLocalConfig(testConfigFilePath)
 	require.NoError(t, err)
+}
+
+func TestDeleteContextSharedServerKeepsReferencedEntries(t *testing.T) {
+	testConfigFilePath := filepath.Join(t.TempDir(), "local.config")
+
+	err := os.WriteFile(testConfigFilePath, []byte(sharedServerConfig), os.ModePerm)
+	require.NoError(t, err)
+
+	err = os.Chmod(testConfigFilePath, 0o600)
+	require.NoError(t, err, "Could not change the file permission to 0600 %v", err)
+
+	err = deleteContext("dev", testConfigFilePath)
+	require.NoError(t, err)
+
+	localCfg, err := config.ReadLocalConfig(testConfigFilePath)
+	require.NoError(t, err)
+	require.NotNil(t, localCfg)
+
+	assert.Equal(t, "", localCfg.CurrentContext)
+	assert.Len(t, localCfg.Contexts, 1)
+	assert.Equal(t, "qa", localCfg.Contexts[0].Name)
+	assert.Len(t, localCfg.Servers, 1)
+	assert.Equal(t, "http://localhost:8585", localCfg.Servers[0].Server)
+	assert.Len(t, localCfg.Users, 1)
+	assert.Equal(t, "http://localhost:8585", localCfg.Users[0].Name)
+	assert.Len(t, localCfg.Instances, 1)
+	assert.Equal(t, "microcks", localCfg.Instances[0].Name)
+	assert.Len(t, localCfg.Auths, 1)
+	assert.Equal(t, "http://localhost:8585", localCfg.Auths[0].Server)
 }

--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -226,6 +226,36 @@ func (l *LocalConfig) RemoveContext(serverName string) (string, bool) {
 	return "", false
 }
 
+func (l *LocalConfig) HasContextUsingServer(server string) bool {
+	for _, c := range l.Contexts {
+		if c.Server == server {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *LocalConfig) HasContextUsingUser(user string) bool {
+	for _, c := range l.Contexts {
+		if c.User == user {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *LocalConfig) HasContextUsingInstance(instance string) bool {
+	if instance == "" {
+		return false
+	}
+	for _, c := range l.Contexts {
+		if c.Instance == instance {
+			return true
+		}
+	}
+	return false
+}
+
 // RemoveToken and returns true if user was removed successfully
 func (l *LocalConfig) RemoveToken(serverName string) bool {
 	for i, u := range l.Users {


### PR DESCRIPTION
### Summary

  This fixes context deletion when multiple contexts reference the same server entry.

  If the config contains a single server and multiple contexts pointing to it,
  deleting one context could also remove shared metadata that was still needed by the
  remaining context.

  ### Changes

  - resolve the target context before deleting it
  - delete only the selected context
  - remove shared `user`, `server`, `auth`, and `instance` entries only when no
  remaining context references them
  - add a regression test for multiple contexts sharing one server

  ### Reproducer

  ```bash
  ./microcks start
  ./microcks login http://localhost:8585 --name dev
  ./microcks context dev --delete
```
```bash
❯ cat ~/.config/microcks/config
cat: /home/syedowais/.config/microcks/config: No such file or directory

```

  ### Testing
```bash
  go test ./cmd ./pkg/config
```

closes: https://github.com/microcks/microcks-cli/issues/421