### PR TITLE
feat: Automatically open Microcks Dashboard in the browser for better DX

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -7,6 +7,7 @@ import (
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
 	"github.com/microcks/microcks-cli/pkg/errors"
+	"github.com/microcks/microcks-cli/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,7 @@ func NewStartCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command 
 		imageName  string
 		autoRemove bool
 		driver     string
+		launchBrowser bool
 	)
 	var startCmd = &cobra.Command{
 		Use:   "start",
@@ -141,6 +143,7 @@ microcks start --name [name of you container/instance]`,
 			errors.CheckError(err)
 
 			fmt.Printf("Microcks started successfully at %s\n", server)
+			util.LaunchBrowser(server, launchBrowser)
 		},
 	}
 	startCmd.Flags().StringVar(&name, "name", "microcks", "name for you microcks instance")
@@ -148,5 +151,6 @@ microcks start --name [name of you container/instance]`,
 	startCmd.Flags().StringVar(&imageName, "image", "quay.io/microcks/microcks-uber:latest-native", "image which will be used to create a container")
 	startCmd.Flags().BoolVar(&autoRemove, "rm", false, "mimic of '--rm' flag of dokcer to automatically remove the container when it exits")
 	startCmd.Flags().StringVar(&driver, "driver", "docker", "use --driver to change driver from docker to podman")
+	startCmd.Flags().BoolVar(&launchBrowser, "launch-browser", true, "Automatically launch browser to the Microcks dashboard")
 	return startCmd
 }

--- a/pkg/util/browser.go
+++ b/pkg/util/browser.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/skratchdot/open-golang/open"
+)
+
+/*
+LaunchBrowser opens the default system browser to the specified URL if conditions are met.
+It skips opening the browser if the launchBrowser flag is false, if running in a CI environment,
+or if the MICROCKS_NO_BROWSER environment variable is set.
+*/
+func LaunchBrowser(url string, launchBrowser bool) {
+	if !launchBrowser {
+		return
+	}
+
+	if os.Getenv("CI") != "" {
+		//if in CI environment, do not attempt to open browser
+		return
+	}
+
+	if os.Getenv("MICROCKS_NO_BROWSER") != "" {
+		// if MICROCKS_NO_BROWSER environment variable is set, do not attempt to open browser
+		return
+	}
+
+	fmt.Printf("Opening system default browser for %s\n", url)
+	err := open.Start(url)
+	if err != nil {
+		fmt.Printf("Failed to open browser: %v\n", err)
+	}
+}


### PR DESCRIPTION
### Description

This enhancement introduces a mechanism to automatically launch the system's default web browser when the CLI
  outputs a link to the Microcks UI. 

  Changes to be introduced:
   1. Centralized Browser Utility: A new package pkg/util to handle cross-platform browser launching with safety
      checks.
   2. Environment Awareness: The CLI will detect if it is running in a headless environment (CI/CD) or if the user
      has globally disabled browser launching via environment variables (MICROCKS_NO_BROWSER).
   3. Command Updates: 
       * microcks start will open the main dashboard.
       * microcks test will open the specific Test Result page.
   4. User Control: A new flag --launch-browser (defaulting to true) will be added to relevant commands to allow
      manual overrides.

### Design Flow

```mermaid
flowchart TD
    A[Run command] --> B{Browser enabled?}
    B -->|No| C[Continue]
    B -->|Yes| D{CI/CD environment?}
    D -->|Yes| E[Skip]
    D -->|No| F[Open browser]
```

### Milestones

- **PR 1:** Browser utility + `microcks start` (Current)

## I will start after approving the Prev PR
- **PR 2:** `microcks test`
- **PR 3 (optional):** Refactor `microcks login` + persistent config

### Related issue(s) :  #423

<!-- Add related issues -->