### PR TITLE
feat: Auto-launch browser for test results and fix CreateTestResult panic

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
 	"github.com/microcks/microcks-cli/pkg/errors"
+	"github.com/microcks/microcks-cli/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +40,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 		filteredOperations string
 		operationsHeaders  string
 		oAuth2Context      string
+		launchBrowser      bool
 	)
 	var testCmd = &cobra.Command{
 
@@ -189,7 +191,9 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				time.Sleep(2 * time.Second)
 			}
 
-			fmt.Printf("Full TestResult details are available here: %s/#/tests/%s \n", serverAddr, testResultID)
+			testResultURL := fmt.Sprintf("%s/#/tests/%s", serverAddr, testResultID)
+			fmt.Printf("Full TestResult details are available here: %s \n", testResultURL)
+			util.LaunchBrowser(testResultURL, launchBrowser)
 
 			if !success {
 				os.Exit(1)
@@ -202,6 +206,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 	testCmd.Flags().StringVar(&filteredOperations, "filteredOperations", "", "List of operations to launch a test for")
 	testCmd.Flags().StringVar(&operationsHeaders, "operationsHeaders", "", "Override of operations headers as JSON string")
 	testCmd.Flags().StringVar(&oAuth2Context, "oAuth2Context", "", "Spec of an OAuth2 client context as JSON string")
+	testCmd.Flags().BoolVar(&launchBrowser, "launch-browser", true, "Automatically launch the system browser to the Microcks test result")
 
 	return testCmd
 }

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -367,16 +367,24 @@ func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string,
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", err
+	}
+
+	// Raise exception if not created.
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "", errs.New(string(body))
 	}
 
 	var createTestResp map[string]interface{}
 	if err := json.Unmarshal(body, &createTestResp); err != nil {
-		panic(err)
+		return "", err
 	}
 
-	testID := createTestResp["id"].(string)
-	return testID, err
+	testID, ok := createTestResp["id"].(string)
+	if !ok {
+		return "", errs.New("Microcks response is missing 'id' field")
+	}
+	return testID, nil
 }
 
 func (c *microcksClient) GetTestResult(testResultID string) (*TestResultSummary, error) {


### PR DESCRIPTION
### Description

This enhancement introduces a mechanism to automatically launch the full visual report in the Microcks UI  web browser instead of clicking it manually to enhance DX


 It completes the "Feedback Loop" for the developer. You run the test, and the evidence opens automatically in your
 browser.
###   Changes introduced:
   1. test command integration: The CLI now automatically launches the system browser to the specific testResultID
      URL upon completion.
   2. Stability Fix: Refactored pkg/connectors/microcks_client.go to handle non-200 HTTP responses. Previously, the
      CLI would panic (crash) if the serviceId was wrong or the server had an error.
   3. Command-line Control: Added the --launch-browser flag to the test command.

  Will this be a breaking change?
  No.

###   Implementation ideas
   * Utilized the util.LaunchBrowser foundation from PR #424 .
   * Added resp.StatusCode validation in the Microcks Client to ensure the CLI fails gracefully with a message
     instead of a panic.

  ---



