### PR TITLE
refactor: Add global browser configuration and unify login logic

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -19,8 +19,8 @@ import (
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
 	"github.com/microcks/microcks-cli/pkg/errors"
+	"github.com/microcks/microcks-cli/pkg/util"
 	"github.com/microcks/microcks-cli/pkg/util/rand"
-	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 	"golang.org/x/term"
@@ -300,9 +300,7 @@ func oauth2login(
 
 func ssoAuthFlow(url string, ssoLaunchBrowser bool) {
 	if ssoLaunchBrowser {
-		fmt.Printf("Opening system default browser for authentication\n")
-		err := open.Start(url)
-		errors.CheckError(err)
+		util.LaunchBrowser(url, ssoLaunchBrowser)
 	} else {
 		fmt.Printf("To authenticate, copy-and-paste the following URL into your preferred browser: %s\n", url)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -7,16 +7,18 @@ import (
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
 	"github.com/microcks/microcks-cli/pkg/errors"
+	"github.com/microcks/microcks-cli/pkg/util"
 	"github.com/spf13/cobra"
 )
 
 func NewStartCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 	var (
-		name       string
-		hostPort   string
-		imageName  string
-		autoRemove bool
-		driver     string
+		name          string
+		hostPort      string
+		imageName     string
+		autoRemove    bool
+		driver        string
+		launchBrowser bool
 	)
 	var startCmd = &cobra.Command{
 		Use:   "start",
@@ -141,6 +143,12 @@ microcks start --name [name of you container/instance]`,
 			errors.CheckError(err)
 
 			fmt.Printf("Microcks started successfully at %s\n", server)
+
+			// Check global config if flag was not explicitly changed
+			if !cmd.Flags().Changed("launch-browser") {
+				launchBrowser = localConfig.GetLaunchBrowser()
+			}
+			util.LaunchBrowser(server, launchBrowser)
 		},
 	}
 	startCmd.Flags().StringVar(&name, "name", "microcks", "name for you microcks instance")
@@ -148,5 +156,6 @@ microcks start --name [name of you container/instance]`,
 	startCmd.Flags().StringVar(&imageName, "image", "quay.io/microcks/microcks-uber:latest-native", "image which will be used to create a container")
 	startCmd.Flags().BoolVar(&autoRemove, "rm", false, "mimic of '--rm' flag of dokcer to automatically remove the container when it exits")
 	startCmd.Flags().StringVar(&driver, "driver", "docker", "use --driver to change driver from docker to podman")
+	startCmd.Flags().BoolVar(&launchBrowser, "launch-browser", true, "Automatically launch the system browser to the Microcks dashboard")
 	return startCmd
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/microcks/microcks-cli/pkg/config"
 	"github.com/microcks/microcks-cli/pkg/connectors"
 	"github.com/microcks/microcks-cli/pkg/errors"
+	"github.com/microcks/microcks-cli/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +40,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 		filteredOperations string
 		operationsHeaders  string
 		oAuth2Context      string
+		launchBrowser      bool
 	)
 	var testCmd = &cobra.Command{
 
@@ -189,7 +191,14 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				time.Sleep(2 * time.Second)
 			}
 
-			fmt.Printf("Full TestResult details are available here: %s/#/tests/%s \n", serverAddr, testResultID)
+			testResultURL := fmt.Sprintf("%s/#/tests/%s", serverAddr, testResultID)
+			fmt.Printf("Full TestResult details are available here: %s \n", testResultURL)
+
+			// Check global config if flag was not explicitly changed
+			if !cmd.Flags().Changed("launch-browser") && localConfig != nil {
+				launchBrowser = localConfig.GetLaunchBrowser()
+			}
+			util.LaunchBrowser(testResultURL, launchBrowser)
 
 			if !success {
 				os.Exit(1)
@@ -202,6 +211,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 	testCmd.Flags().StringVar(&filteredOperations, "filteredOperations", "", "List of operations to launch a test for")
 	testCmd.Flags().StringVar(&operationsHeaders, "operationsHeaders", "", "Override of operations headers as JSON string")
 	testCmd.Flags().StringVar(&oAuth2Context, "oAuth2Context", "", "Spec of an OAuth2 client context as JSON string")
+	testCmd.Flags().BoolVar(&launchBrowser, "launch-browser", true, "Automatically launch the system browser to the Microcks test result")
 
 	return testCmd
 }

--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -16,8 +16,16 @@ type LocalConfig struct {
 	Users          []User       `yaml:"users"`
 	Instances      []Instance   `yaml:"instances"`
 	Auths          []Auth       `yaml:"auths"`
+	LaunchBrowser  *bool        `yaml:"launch-browser,omitempty"`
 }
 
+// GetLaunchBrowser returns the global preference for launching browser. Default is true.
+func (l *LocalConfig) GetLaunchBrowser() bool {
+	if l.LaunchBrowser == nil {
+		return true
+	}
+	return *l.LaunchBrowser
+}
 type ContextRef struct {
 	Name     string `yaml:"name"`
 	Server   string `yaml:"server"`


### PR DESCRIPTION
### Description

This PR extends the browser auto-launch enhancement by adding global configuration support and unifying browser behavior across commands.

### What’s Included

- Added `launch-browser` to the Microcks config schema
- Updated `microcks start` and `microcks test` to respect config and CLI overrides
- Refactored `microcks login` to use the centralized browser utility
- Ensured DCO-compliant commits and clean branch history

### Related issue(s)

This PR continues works on #423 and #425