### PR TITLE
fix: validate numeric part of --waitFor flag in test command

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -75,10 +75,33 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			}
 
 			// Validate presence and values of flags.
-			if !strings.HasSuffix(waitFor, "milli") && !strings.HasSuffix(waitFor, "sec") && !strings.HasSuffix(waitFor, "min") {
-				fmt.Println("--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)")
-				os.Exit(1)
-			}
+if !strings.HasSuffix(waitFor, "milli") && !strings.HasSuffix(waitFor, "sec") && !strings.HasSuffix(waitFor, "min") {
+    fmt.Println("--waitFor format is wrong. Accepted units are: milli, sec, min (e.g. 500milli, 30sec, 5min)")
+    os.Exit(1)
+}
+
+// Validate that numeric part of --waitFor is present and greater than zero.
+var numericPart string
+if strings.HasSuffix(waitFor, "milli") {
+	numericPart = waitFor[:len(waitFor)-5]
+} else if strings.HasSuffix(waitFor, "sec") {
+	numericPart = waitFor[:len(waitFor)-3]
+} else if strings.HasSuffix(waitFor, "min") {
+	numericPart = waitFor[:len(waitFor)-3]
+}
+if numericPart == "" {
+	fmt.Printf("--waitFor value %q is missing numeric part (e.g. 5sec, 500milli, 1min)\n", waitFor)
+	os.Exit(1)
+}
+numericVal, err := strconv.ParseInt(numericPart, 0, 64)
+if err != nil {
+	fmt.Printf("--waitFor value %q has invalid numeric part: must be a valid integer\n", waitFor)
+	os.Exit(1)
+}
+if numericVal <= 0 {
+	fmt.Printf("--waitFor value %q must be greater than zero\n", waitFor)
+	os.Exit(1)
+}
 
 			// Collect optional HTTPS transport flags.
 			config.InsecureTLS = globalClientOpts.InsecureTLS
@@ -170,7 +193,7 @@ func NewTestCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			}
 
 			var testResultID string
-			testResultID, err := mc.CreateTestResult(serviceRef, testEndpoint, runnerType, secretName, waitForMilliseconds, filteredOperations, operationsHeaders, oAuth2Context)
+			testResultID, err = mc.CreateTestResult(serviceRef, testEndpoint, runnerType, secretName, waitForMilliseconds, filteredOperations, operationsHeaders, oAuth2Context)
 			if err != nil {
 				fmt.Printf("Got error when invoking Microcks client creating Test: %s", err)
 				os.Exit(1)


### PR DESCRIPTION
## Summary
Adds proper validation for the numeric part of the --waitFor flag.

## Problem
Current validation only checks the suffix (milli/sec/min) but not 
the numeric part. This allows invalid values like:
- --waitFor=sec (no number) 
- --waitFor=0sec (zero is invalid)
- --waitFor=abcsec (non-numeric)

These pass validation but cause unexpected behavior during execution.

## Fix
Added validation that ensures:
- Numeric part must be present (e.g. 5sec not sec)
- Numeric part must be a valid integer
- Value must be greater than zero

## Example error messages after fix
--waitFor=sec → "--waitFor value "sec" is missing numeric part (e.g. 5sec)"
--waitFor=0sec → "--waitFor value "0sec" must be greater than zero"
--waitFor=abcsec → "--waitFor value "abcsec" has invalid numeric part"

## Files Changed
- cmd/test.go — added numeric validation for --waitFor flag

Closes #430