### PR TITLE
Fix watcher stopping after atomic file saves

### DIFF
--- a/pkg/watcher/watchManager.go
+++ b/pkg/watcher/watchManager.go
@@ -3,7 +3,9 @@ package watcher
 import (
 	"fmt"
 	"log"
+	"os"
 	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/microcks/microcks-cli/pkg/config"
@@ -81,7 +83,7 @@ func (wm *WatchManager) Run() {
 	for {
 		select {
 		case event := <-wm.fileWatcher.Events:
-			if event.Op&fsnotify.Write == fsnotify.Write {
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename|fsnotify.Remove) != 0 {
 				if event.Name == wm.configPath {
 					fmt.Println("[INFO] Reloading config...")
 					wm.lock.Lock()
@@ -95,7 +97,21 @@ func (wm *WatchManager) Run() {
 					entry, exists := wm.watchEntries[event.Name]
 					wm.lock.Unlock()
 					if exists {
-						go TriggerImport(entry)
+						// Re-establish watch if the file was replaced atomically (rename or remove).
+						if event.Op&(fsnotify.Rename|fsnotify.Remove) != 0 {
+							_ = wm.fileWatcher.Remove(event.Name)
+							time.Sleep(50 * time.Millisecond) // Let the OS complete the rename/replace operation
+							if _, err := os.Stat(event.Name); err == nil {
+								if err := wm.fileWatcher.Add(event.Name); err != nil {
+									time.Sleep(100 * time.Millisecond) // Retry once on slow file systems
+									_ = wm.fileWatcher.Add(event.Name)
+								}
+							}
+						}
+
+						if event.Op&fsnotify.Remove == 0 {
+							go TriggerImport(entry)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### Description
This fixes an issue where microcks import --watch stops detecting file changes after the first save when using editors like VS Code. 
The problem happens because many editors use atomic saves internally (write temp file + rename), which causes fsnotify to emit Rename/Remove events and drop the existing watch on the original file.

Changes
Expanded watcher event handling to also process:
fsnotify.Create
fsnotify.Rename
fsnotify.Remove
Re-register the watcher when a watched file is replaced during an atomic save.
Added existence checks before re-adding the watch to avoid issues when files are actually deleted.
Prevent imports from triggering on permanent file removal.

Reproduction
Before this change: Run: microcks import --watch spec.yaml
Edit and save spec.yaml in VS Code
First save triggers import correctly
Second save is ignored because the watch is no longer active. After this change, repeated saves continue triggering imports correctly.

Testing manually with VsCode and multiple consecutive saves continue triggering imports, watcher recovers after atomic rename operations, also no panic occurs on deletion of file.

### Related issue(s) #432 

