### PR TITLE
fix: continue importing remaining URLs on failure in import-url command

### DIFF
--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -95,6 +95,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 					return
 				}
 			}
+			var hasErrors bool
 			sepSpecificationFiles := strings.Split(specificationFiles, ",")
 			for _, f := range sepSpecificationFiles {
 				mainArtifact := true
@@ -120,10 +121,14 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 				// Try downloading the artifcat
 				msg, err := mc.DownloadArtifact(f, mainArtifact, secret)
 				if err != nil {
-					fmt.Printf("Got error when invoking Microcks client importing Artifact: %s", err)
-					os.Exit(1)
+					fmt.Printf("Failed to import '%s': %s\n", f, err)
+					hasErrors = true
+					continue
 				}
 				fmt.Printf("Microcks has discovered '%s'\n", msg)
+			}
+			if hasErrors {
+				os.Exit(1)
 			}
 		},
 	}


### PR DESCRIPTION
## Summary
Fix early exit bug in import-url command when importing multiple URLs.

## Problem
When running:
microcks import-url "https://url1.yaml,https://url2.yaml,https://url3.yaml"

If url1 fails, os.Exit(1) is called immediately and url2, url3 
are never imported. Same bug as #393 which was fixed in import 
command via PR #394.

## Fix
- Replaced os.Exit(1) with error collection and continue
- All URLs are attempted regardless of individual failures
- Exit with code 1 only if any URL failed

## Example output after fix
Failed to import 'https://url2.yaml': connection refused
Microcks has discovered 'https://url1.yaml'
Microcks has discovered 'https://url3.yaml'

## Files Changed
- cmd/importURL.go — replaced os.Exit(1) with hasErrors flag and continue

Closes #399