### PR TITLE
fix: clean up auth when deleting named contexts

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -73,12 +73,13 @@ func deleteContext(context, configPath string) error {
 	if localCfg == nil {
 		return fmt.Errorf("Nothing to logout from")
 	}
-	serverName, ok := localCfg.RemoveContext(context)
+	contextRef, ok := localCfg.RemoveContext(context)
 	if !ok {
 		return fmt.Errorf("Context %s does not exist", context)
 	}
-	_ = localCfg.RemoveUser(context)
-	_ = localCfg.RemoveServer(serverName)
+	_ = localCfg.RemoveUser(contextRef.User)
+	_ = localCfg.RemoveServer(contextRef.Server)
+	_ = localCfg.RemoveAuth(contextRef.Server)
 
 	if localCfg.IsEmpty() {
 		err := localCfg.DeleteLocalConfig(configPath)

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -65,8 +65,56 @@ func TestDeleteContext(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDeleteContextEmpty(t *testing.T) {
-	err := deleteContext("http://localhost:8080", "./testdata/non-existent-file.config")
-	require.EqualError(t, err, "Nothing to logout from")
-}
+func TestDeleteNamedContextRemovesReferencedUserAndAuth(t *testing.T) {
+	configPath := t.TempDir() + "/config"
+	localConfig := `current-context: staging
+contexts:
+- name: dev
+  server: http://localhost:8080
+  user: http://localhost:8080
+  instance: ""
+- name: staging
+  server: http://localhost:8083
+  user: http://localhost:8083
+  instance: ""
+servers:
+- name: ""
+  server: http://localhost:8080
+  insecureTLS: true
+  keycloakEnable: true
+- name: ""
+  server: http://localhost:8083
+  insecureTLS: true
+  keycloakEnable: true
+users:
+- name: http://localhost:8080
+  auth-token: stale-token
+  refresh-token: stale-refresh-token
+- name: http://localhost:8083
+  auth-token: ""
+  refresh-token: ""
+auths:
+- server: http://localhost:8080
+  clientid: my-client
+  clientsecret: my-secret
+`
 
+	err := os.WriteFile(configPath, []byte(localConfig), os.ModePerm)
+	require.NoError(t, err)
+	err = os.Chmod(configPath, 0o600)
+	require.NoError(t, err)
+
+	err = deleteContext("dev", configPath)
+	require.NoError(t, err)
+
+	localCfg, err := config.ReadLocalConfig(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, localCfg)
+
+	assert.Equal(t, "staging", localCfg.CurrentContext)
+	assert.NotContains(t, localCfg.Contexts, config.ContextRef{Name: "dev", Server: "http://localhost:8080", User: "http://localhost:8080", Instance: ""})
+	assert.NotContains(t, localCfg.Servers, config.Server{Server: "http://localhost:8080", InsecureTLS: true, KeycloakEnable: true})
+	assert.NotContains(t, localCfg.Users, config.User{Name: "http://localhost:8080", AuthToken: "stale-token", RefreshToken: "stale-refresh-token"})
+	assert.NotContains(t, localCfg.Auths, config.Auth{Server: "http://localhost:8080", ClientId: "my-client", ClientSecret: "my-secret"})
+	assert.Contains(t, localCfg.Contexts, config.ContextRef{Name: "staging", Server: "http://localhost:8083", User: "http://localhost:8083", Instance: ""})
+}

--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -215,15 +215,15 @@ func (l *LocalConfig) UpsertContext(context ContextRef) {
 	l.Contexts = append(l.Contexts, context)
 }
 
-// RemoveContext and returns server name and true if context was removed successfully
-func (l *LocalConfig) RemoveContext(serverName string) (string, bool) {
+// RemoveContext removes a context reference and returns it if context was removed successfully.
+func (l *LocalConfig) RemoveContext(name string) (ContextRef, bool) {
 	for i, c := range l.Contexts {
-		if c.Name == serverName {
+		if c.Name == name {
 			l.Contexts = append(l.Contexts[:i], l.Contexts[i+1:]...)
-			return c.Server, true
+			return c, true
 		}
 	}
-	return "", false
+	return ContextRef{}, false
 }
 
 // RemoveToken and returns true if user was removed successfully


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Fixes named context deletion so cleanup uses the removed context's referenced `user` and `server` values instead of the context name.
- Removes the associated auth entry when deleting a context, matching the expected cleanup behavior for credentials tied to that server.
- Adds a regression test covering `context --delete` for a named context where `contexts[].name` differs from `contexts[].user`.

### Screenshot
<img width="1221" height="527" alt="Screenshot From 2026-05-25 12-04-04" src="https://github.com/user-attachments/assets/f5c8be3d-3537-4b4d-80cc-5b5459cbf484" />


### Related issue(s)

Fixes #427 