### PR TITLE
fix: remove duplicate status check and add missing port flag description in start command

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -47,11 +47,7 @@ microcks start --name [name of you container/instance]`,
 				instance = &config.Instance{}
 			}
 
-			if instance.Status == "Running" {
-				fmt.Printf("Microcks instance with name %s is already running", name)
-				return
-			}
-
+			
 			switch instance.Status {
 			case "Running":
 				fmt.Printf("Microcks instance with name %s is already running", name)
@@ -144,7 +140,7 @@ microcks start --name [name of you container/instance]`,
 		},
 	}
 	startCmd.Flags().StringVar(&name, "name", "microcks", "name for you microcks instance")
-	startCmd.Flags().StringVar(&hostPort, "port", "8585", "")
+	startCmd.Flags().StringVar(&hostPort, "port", "8585", "Host port to expose the Microcks instance (default: 8585)")
 	startCmd.Flags().StringVar(&imageName, "image", "quay.io/microcks/microcks-uber:latest-native", "image which will be used to create a container")
 	startCmd.Flags().BoolVar(&autoRemove, "rm", false, "mimic of '--rm' flag of dokcer to automatically remove the container when it exits")
 	startCmd.Flags().StringVar(&driver, "driver", "docker", "use --driver to change driver from docker to podman")


### PR DESCRIPTION
## Summary
Two small but genuine fixes in cmd/start.go.

## Fix 1 — Remove duplicate Running status check
The `Running` status was being checked twice:
1. First via an explicit if block before the switch
2. Then again as a case inside the switch statement

The duplicate check was redundant and has been removed.

## Fix 2 — Add missing --port flag description
The --port flag had an empty description string:
startCmd.Flags().StringVar(&hostPort, "port", "8585", "")

Users running microcks start --help had no idea what --port does.
Added a proper description.

## Files Changed
- cmd/start.go — removed duplicate check, added port flag description