### PR TITLE
fix: add --name flag to stop command and remove empty println

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -12,6 +12,7 @@ import (
 
 func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 
+	var name string
 	var stopCmd = &cobra.Command{
 		Use:   "stop",
 		Short: "stop microcks instance",
@@ -27,7 +28,7 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				return
 			}
 
-			ctx, err := localConfig.ResolveContext("")
+			ctx, err := localConfig.ResolveContext(name)
 			errors.CheckError(err)
 			instance := ctx.Instance
 
@@ -45,7 +46,7 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				log.Fatalf("Failed to stop a container: %v", err)
 				return
 			}
-			fmt.Println("")
+			
 			log.Printf("Instance %s stopped successfully", instance.Name)
 
 			// update configs
@@ -72,6 +73,7 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			errors.CheckError(err)
 		},
 	}
+	stopCmd.Flags().StringVar(&name, "name", "", "Name of the Microcks instance to stop")
 
 	return stopCmd
 }


### PR DESCRIPTION
## Summary
Adds --name flag to stop command for consistency with start command.

## Problem
The start command supports --name flag to name a Microcks instance
but the stop command has no --name flag:

microcks start --name myinstance  ✅ works
microcks stop --name myinstance   ❌ flag did not exist

Users could not specify which instance to stop when multiple 
instances exist. The stop command always resolved the current 
context instead.

## Fix
- Added --name flag to stop command
- Pass name to ResolveContext() so correct instance is stopped
- Removed unnecessary empty fmt.Println() call

## Files Changed
- cmd/stop.go — added --name flag, removed empty println

Closes #438