### PR TITLE
fix(config): use path/filepath for OS-correct path separators

### DIFF
--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -3,7 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"slices"
 
 	configUtil "github.com/microcks/microcks-cli/pkg/util"
@@ -109,7 +109,7 @@ func DefaultConfigDir() (string, error) {
 		return "", nil
 	}
 
-	configDir = path.Join(homeDir, ".config", "microcks")
+	configDir = filepath.Join(homeDir, ".config", "microcks")
 
 	return configDir, nil
 }
@@ -130,7 +130,7 @@ func DefaultLocalConfigPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(dir, "config"), nil
+	return filepath.Join(dir, "config"), nil
 }
 
 // DefaultLocalWatchPath returns the local watch configuration path.
@@ -139,7 +139,7 @@ func DefaultLocalWatchPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(dir, "watch"), nil
+	return filepath.Join(dir, "watch"), nil
 }
 
 // ValidateLocalConfig validates the local configuration.
@@ -155,7 +155,7 @@ func ValidateLocalConfig(config LocalConfig) error {
 
 // WriteLocalConfig writes a new local configuration file.
 func WriteLocalConfig(config LocalConfig, configPath string) error {
-	err := os.MkdirAll(path.Dir(configPath), os.ModePerm)
+	err := os.MkdirAll(filepath.Dir(configPath), os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func ReadLocalWatchConfig(path string) (*WatchConfig, error) {
 
 // WriteLocalWatchConfig writes a new local watch configuration file.
 func WriteLocalWatchConfig(config WatchConfig, cfgPath string) error {
-	err := os.MkdirAll(path.Dir(cfgPath), os.ModePerm)
+	err := os.MkdirAll(filepath.Dir(cfgPath), os.ModePerm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Replace the `path` package with `path/filepath` in `pkg/config/localconfig.go`
so the CLI builds filesystem paths with the OS-correct separator.

Fixes #441 .

## Background

The Go standard library splits path manipulation across two packages:

- `path` — always uses `/`. Meant for URLs and slash-separated paths.
- `path/filepath` — uses the OS-specific separator. Meant for filesystem paths.

`localconfig.go` was using `path.Join` / `path.Dir` to construct filesystem
paths. On Windows this produced mixed-separator paths because `os.UserHomeDir()`
returns backslashes but `path.Join` then appended with forward slashes.

## Changes

`pkg/config/localconfig.go`:
- Replaced `import "path"` with `import "path/filepath"`.
- Replaced 3 `path.Join` calls with `filepath.Join` (lines 112, 133, 142).
- Replaced 2 `path.Dir` calls with `filepath.Dir` (lines 158, 410).

No other files needed changes — `path` was only used in this file for filesystem
path construction.

## Before / After (Windows 11)

Before:
<img width="1069" height="62" alt="WhatsApp Image 2026-05-27 at 00 38 06" src="https://github.com/user-attachments/assets/cbf4ed73-2e5d-4b22-936d-76cb474e569b" />
```


> microcks --help
      --config string   Path to Microcks config (default "C:\Users\<USER>/.config/microcks/config")
> microcks context
2026/05/27 00:35:59 No contexts defined in C:\Users\<USER>/.config/microcks/config
```


After:
<img width="824" height="62" alt="image" src="https://github.com/user-attachments/assets/99544841-f354-4a64-b26a-0b89f946e920" />
```


> microcks --help
      --config string   Path to Microcks config (default "C:\Users\<USER>\.config\microcks\config")
> microcks context
2026/05/27 00:35:59 No contexts defined in C:\Users\<USER>\.config\microcks\config
```

Linux / macOS output is unchanged.

## Test plan

- [x] `go build .` succeeds on Windows.
- [x] `microcks --help` shows all-backslash default config path on Windows.
- [x] `microcks context` shows all-backslash path on Windows.
- [ ] CI passes on all platforms.

## Related

This is in the same family as #352 / PR #353 (Windows absolute path parsing).
