### PR TITLE
docs: fix typos in config and connector messages

### DIFF
--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -345,7 +345,7 @@ func (l *LocalConfig) GetAuth(server string) (*Auth, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("Auth for '%s' is undifined", server)
+	return nil, fmt.Errorf("Auth for '%s' is undefined", server)
 }
 
 func (l *LocalConfig) UpsertAuth(auth Auth) {

--- a/pkg/connectors/keycloak_client.go
+++ b/pkg/connectors/keycloak_client.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// KeycloakClient defines methods for cinteracting with Keycloak
+// KeycloakClient defines methods for interacting with Keycloak
 type KeycloakClient interface {
 	ConnectAndGetToken() (string, error)
 	ConnectAndGetTokenAndRefreshToken(string, string) (string, string, error)


### PR DESCRIPTION
## Description

This PR fixes two small typos in user-facing/project text.

### Changes

1. Fixed typo in `pkg/connectors/keycloak_client.go`

```diff
- cinteracting
+ interacting
```

2. Fixed typo in `pkg/config/localconfig.go`

```diff
- Auth for '%s' is undifined
+ Auth for '%s' is undefined
```

## Why

- Improves readability and professionalism of user-facing messages.
- Removes confusing wording in authentication error output.
- No behavioral or functional changes.

## Type of change

- Documentation / text cleanup
- Non-breaking change

## Verification

```bash
grep -RIn "cinteracting\|undifined" pkg
go test ./...
```

Confirmed both typos are removed and tests continue to pass.