### PR TITLE
fix: remove unused Insecure field incorrectly assigned KeycloackEnabl…

### DIFF
--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -104,7 +104,6 @@ type microcksClient struct {
 	CertFile     *tls.Certificate
 	InsecureTLS  bool
 	RefreshToken string
-	Insecure     bool
 	Verbose      bool
 
 	httpClient *http.Client
@@ -135,7 +134,7 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 			return nil, err
 		}
 		c.ServerAddr = configCtx.Server.Server
-		c.Insecure = configCtx.Server.KeycloakEnable
+
 		c.InsecureTLS = configCtx.Server.InsecureTLS
 		c.AuthToken = configCtx.User.AuthToken
 		c.RefreshToken = configCtx.User.RefreshToken


### PR DESCRIPTION
### Description

- **Bug**: In `pkg/connectors/microcks_client.go`, the `NewClient` function incorrectly assigned `configCtx.Server.KeycloakEnable` (a boolean flag for Keycloak authentication) to the `c.Insecure` field (which semantically represents TLS insecurity). This meant that when Keycloak was enabled, `c.Insecure` was set to `true` - a completely unrelated concern.
- **Fix**: Removed the unused `Insecure` field from the `microcksClient` struct and its incorrect assignment (`c.Insecure = configCtx.Server.KeycloakEnable`) in `NewClient`.
- **Rationale**: The `Insecure` field was never read anywhere in the codebase after being assigned, making it dead code. The `InsecureTLS` field already correctly handles TLS skip-verify behavior via `configCtx.Server.InsecureTLS`, so no functionality is lost.

### Related issue(s)

Fixes #434
