### PR TITLE
fix: panic on nil type assertion when testing unregistered service

### DIFF
--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -376,21 +376,26 @@ func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string,
 	}
 	defer resp.Body.Close()
 
-	// Dump response if verbose required.
-	config.DumpResponseIfRequired("Microcks for creating test", resp, true)
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Check HTTP status before attempting to parse.
+	if resp.StatusCode != 201 {
+		return "", fmt.Errorf("microcks returned HTTP %d: %s (is the service '%s' registered?)", resp.StatusCode, strings.TrimSpace(string(body)), serviceID)
 	}
 
 	var createTestResp map[string]interface{}
 	if err := json.Unmarshal(body, &createTestResp); err != nil {
-		panic(err)
+		return "", fmt.Errorf("failed to parse test creation response: %w", err)
 	}
 
-	testID := createTestResp["id"].(string)
-	return testID, err
+	testID, ok := createTestResp["id"].(string)
+	if !ok || testID == "" {
+		return "", fmt.Errorf("microcks response missing 'id' field")
+	}
+	return testID, nil
 }
 
 func (c *microcksClient) GetTestResult(testResultID string) (*TestResultSummary, error) {


### PR DESCRIPTION
## Problem

Running `microcks test` against a service that isn't registered in Microcks
causes a panic instead of a clean error:

```panic: interface conversion: interface {} is nil, not string```

This happens in `CreateTestResult` because the server returns a non-201
response (with no `"id"` field) when the service is unknown, and the code
does a bare type assertion `createTestResp["id"].(string)` without checking
the HTTP status first.

## Fix

- Check `resp.StatusCode` before attempting to parse the response body.
  If it's not 201, return a descriptive error including the HTTP status,
  server message, and service name.
- Replace the bare type assertion with a comma-ok check as a second
  line of defense.
- Replace `panic(err.Error())` on `io.ReadAll` with a proper error return.

## Before
<img width="963" height="486" alt="Screenshot from 2026-06-11 02-25-57" src="https://github.com/user-attachments/assets/984d8000-7fd4-4eb8-8e1e-2c23eb359071" />

## After


<img width="960" height="162" alt="Screenshot from 2026-06-11 02-26-12" src="https://github.com/user-attachments/assets/b832ba83-b935-47bc-896a-7770ea55b51a" />

Fixes: https://github.com/microcks/microcks-cli/issues/454
