### PR TITLE
fix(start): reconcile instance status against container runtime before trusting it

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -47,9 +47,24 @@ microcks start --name [name of you container/instance]`,
 				instance = &config.Instance{}
 			}
 
-			if instance.Status == "Running" {
-				fmt.Printf("Microcks instance with name %s is already running", name)
-				return
+			// The recorded status can drift from reality: a system restart,
+			// autoRemove or a manual `docker rm` removes the container while
+			// the config still says Running/Exited. Reconcile before trusting it.
+			if instance.Status != "" && instance.ContainerID != "" {
+				instanceDriver := instance.Driver
+				if instanceDriver == "" {
+					instanceDriver = driver
+				}
+				containerClient, err := connectors.NewContainerClient(instanceDriver)
+				errors.CheckError(err)
+				exists, err := containerClient.ContainerExists(instance.ContainerID)
+				containerClient.CloseClient()
+				errors.CheckError(err)
+				if !exists {
+					fmt.Printf("Container for instance %s no longer exists, recreating it\n", name)
+					instance.Status = ""
+					instance.ContainerID = ""
+				}
 			}
 
 			switch instance.Status {

--- a/pkg/connectors/container_client.go
+++ b/pkg/connectors/container_client.go
@@ -21,6 +21,7 @@ type ContainerClient interface {
 	CreateContainer(opts ContainerOpts) (string, error)
 	StartContainer(containerId string) error
 	StopContainer(continerId string) error
+	ContainerExists(containerId string) (bool, error)
 	CloseClient() error
 }
 
@@ -155,6 +156,21 @@ func (cli *containerClient) StopContainer(containerId string) error {
 	fmt.Print("Stopping container ", containerId, "... ")
 	noWaitTimeout := 0 // to not wait for the container to exit gracefully
 	return cli.cli.ContainerStop(ctx, containerId, container.StopOptions{Timeout: &noWaitTimeout})
+}
+
+// ContainerExists reports whether the container is still known to the
+// runtime. "No such container" is a regular outcome here, not an error,
+// so callers can reconcile stale config entries.
+func (cli *containerClient) ContainerExists(containerId string) (bool, error) {
+	ctx := context.Background()
+	_, err := cli.cli.ContainerInspect(ctx, containerId)
+	if err != nil {
+		if client.IsErrNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (cli *containerClient) CloseClient() error {


### PR DESCRIPTION
### Description
microcks start trusts the cached status: Running in ~/.config/microcks/config. If the container was removed externally (system restart, autoRemove, manual docker rm), the CLI wedges in "already running" with no recovery path.

This adds ContainerExists() to the container client and checks it before trusting the recorded status — a missing container now falls through to the fresh-create path. Also removes a duplicated "Running" check.

Reproduce: 

- `microcks start --name demo`
- `docker rm -f demo` 
- `microcks start --name demo`
- previously "already running", 
- now recreates the container.

### Related issue(s)
An issue I ran into while experimenting with VS Code extension on top of the CLI.
LFX Mentorship
https://github.com/microcks/microcks-cli/issues/255