### PR TITLE
fix(watcher): log swallowed config-load error instead of discarding it

### DIFF
--- a/pkg/watcher/executor.go
+++ b/pkg/watcher/executor.go
@@ -12,7 +12,8 @@ func TriggerImport(entry config.WatchEntry) {
 	// Retrieve config to get client options.
 	cfgPath, err := config.DefaultLocalConfigPath()
 	if err != nil {
-		fmt.Errorf("Error while loading config: %s", err.Error())
+		fmt.Printf("[ERROR] Error while loading config: %s\n", err.Error())
+		return
 	}
 
 	fmt.Println("[INFO] Re-importing changed file: " + entry.FilePath)


### PR DESCRIPTION
## Description

`TriggerImport` in `pkg/watcher/executor.go` built an error with `fmt.Errorf`
on a config-load failure and then discarded the result, so the failure was
silently swallowed — nothing logged, nothing returned, execution continued
with an empty config path.

```go
cfgPath, err := config.DefaultLocalConfigPath()
if err != nil {
    fmt.Errorf("Error while loading config: %s", err.Error())  // result discarded
}
```

Replaced it with a logged error (matching the [ERROR]/[WARN] style the rest
of the function already uses) and an early return, since there's no point
continuing without a config path.

So this also un-breaks go vet ./... for the whole module.

### How verified

```
go vet ./... — now clean (previously reported the error above)
go build ./... and go test ./... pass
```

Surfaced while working on the CLI v2 mentorship. Refs #255