### PR TITLE
fix: preserve mainArtifact default on parse failure in import and import-url

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -124,11 +124,11 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 				if strings.Contains(f, ":") {
 					lastColon := strings.LastIndex(f, ":")
 					boolPart := f[lastColon+1:]
-					f = f[:lastColon]
 					if val, parseErr := strconv.ParseBool(boolPart); parseErr != nil {
 						fmt.Printf("Cannot parse '%s' as Bool, default to true\n", boolPart)
 					} else {
 						mainArtifact = val
+						f = f[:lastColon]
 					}
 				}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -119,15 +119,15 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 			sepSpecificationFiles := strings.Split(specificationFiles, ",")
 			for _, f := range sepSpecificationFiles {
 				mainArtifact := true
-				var err error
 
 				// Check if mainArtifact flag is provided.
 				if strings.Contains(f, ":") {
 					pathAndMainArtifact := strings.Split(f, ":")
 					f = pathAndMainArtifact[0]
-					mainArtifact, err = strconv.ParseBool(pathAndMainArtifact[1])
-					if err != nil {
+					if val, parseErr := strconv.ParseBool(pathAndMainArtifact[1]); parseErr != nil {
 						fmt.Printf("Cannot parse '%s' as Bool, default to true\n", pathAndMainArtifact[1])
+					} else {
+						mainArtifact = val
 					}
 				}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -122,10 +122,11 @@ func NewImportCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command
 
 				// Check if mainArtifact flag is provided.
 				if strings.Contains(f, ":") {
-					pathAndMainArtifact := strings.Split(f, ":")
-					f = pathAndMainArtifact[0]
-					if val, parseErr := strconv.ParseBool(pathAndMainArtifact[1]); parseErr != nil {
-						fmt.Printf("Cannot parse '%s' as Bool, default to true\n", pathAndMainArtifact[1])
+					lastColon := strings.LastIndex(f, ":")
+					boolPart := f[lastColon+1:]
+					f = f[:lastColon]
+					if val, parseErr := strconv.ParseBool(boolPart); parseErr != nil {
+						fmt.Printf("Cannot parse '%s' as Bool, default to true\n", boolPart)
 					} else {
 						mainArtifact = val
 					}

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -100,23 +100,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 				mainArtifact := true
 				secret := ""
 
-				// Check if URL starts with https or http
-				if strings.HasPrefix(f, "https://") || strings.HasPrefix(f, "http://") {
-					urlAndMainAtrifactAndSecretName := strings.Split(f, ":")
-					n := len(urlAndMainAtrifactAndSecretName)
-					f = urlAndMainAtrifactAndSecretName[0] + ":" + urlAndMainAtrifactAndSecretName[1]
-					if n > 2 {
-						val, err := strconv.ParseBool(urlAndMainAtrifactAndSecretName[2])
-						if err != nil {
-							fmt.Printf("Cannot parse '%s' as Bool, default to true\n", urlAndMainAtrifactAndSecretName[2])
-						} else {
-							mainArtifact = val
-						}
-					}
-					if n > 3 {
-						secret = urlAndMainAtrifactAndSecretName[3]
-					}
-				}
+				f, mainArtifact, secret = parseImportURLArg(f)
 
 				// Try downloading the artifcat
 				msg, err := mc.DownloadArtifact(f, mainArtifact, secret)
@@ -130,4 +114,26 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 	}
 
 	return importURLCmd
+}
+
+func parseImportURLArg(f string) (string, bool, string) {
+	mainArtifact := true
+	secret := ""
+
+	if strings.HasPrefix(f, "https://") || strings.HasPrefix(f, "http://") {
+		parts := strings.Split(f, ":")
+		n := len(parts)
+
+		for i := n - 1; i >= 2; i-- {
+			if val, parseErr := strconv.ParseBool(parts[i]); parseErr == nil {
+				mainArtifact = val
+				if i+1 < n {
+					secret = strings.Join(parts[i+1:], ":")
+				}
+				f = strings.Join(parts[:i], ":")
+				break
+			}
+		}
+	}
+	return f, mainArtifact, secret
 }

--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -108,9 +108,10 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 					if n > 2 {
 						val, err := strconv.ParseBool(urlAndMainAtrifactAndSecretName[2])
 						if err != nil {
-							fmt.Println(err)
+							fmt.Printf("Cannot parse '%s' as Bool, default to true\n", urlAndMainAtrifactAndSecretName[2])
+						} else {
+							mainArtifact = val
 						}
-						mainArtifact = val
 					}
 					if n > 3 {
 						secret = urlAndMainAtrifactAndSecretName[3]

--- a/cmd/importURL_test.go
+++ b/cmd/importURL_test.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseImportURLArg(t *testing.T) {
+	tests := []struct {
+		name                string
+		input               string
+		expectedURL         string
+		expectedMainArtifact bool
+		expectedSecret      string
+	}{
+		{
+			name:                "standard URL without suffixes",
+			input:               "https://example.com/openapi.yaml",
+			expectedURL:         "https://example.com/openapi.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "standard URL with mainArtifact true",
+			input:               "https://example.com/spec1.yaml:true",
+			expectedURL:         "https://example.com/spec1.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "standard URL with mainArtifact false",
+			input:               "https://example.com/spec1.yaml:false",
+			expectedURL:         "https://example.com/spec1.yaml",
+			expectedMainArtifact: false,
+			expectedSecret:      "",
+		},
+		{
+			name:                "standard URL with mainArtifact and secret",
+			input:               "https://example.com/spec1.yaml:true:my-secret",
+			expectedURL:         "https://example.com/spec1.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "my-secret",
+		},
+		{
+			name:                "standard URL with mainArtifact false and secret",
+			input:               "https://example.com/spec1.yaml:false:my-secret-token",
+			expectedURL:         "https://example.com/spec1.yaml",
+			expectedMainArtifact: false,
+			expectedSecret:      "my-secret-token",
+		},
+		{
+			name:                "URL with port and no suffixes",
+			input:               "http://localhost:8585/spec.yaml",
+			expectedURL:         "http://localhost:8585/spec.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "URL with port and mainArtifact true",
+			input:               "http://localhost:8585/spec.yaml:true",
+			expectedURL:         "http://localhost:8585/spec.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "URL with port and mainArtifact false",
+			input:               "http://localhost:8585/spec.yaml:false",
+			expectedURL:         "http://localhost:8585/spec.yaml",
+			expectedMainArtifact: false,
+			expectedSecret:      "",
+		},
+		{
+			name:                "URL with port, mainArtifact and secret",
+			input:               "http://localhost:8585/spec.yaml:true:my-secret-token",
+			expectedURL:         "http://localhost:8585/spec.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "my-secret-token",
+		},
+		{
+			name:                "URL with port, mainArtifact false and secret",
+			input:               "http://localhost:8585/spec.yaml:false:my-secret-token",
+			expectedURL:         "http://localhost:8585/spec.yaml",
+			expectedMainArtifact: false,
+			expectedSecret:      "my-secret-token",
+		},
+		{
+			name:                "malformed bool suffix preserves URL",
+			input:               "http://localhost:8585/spec.yaml:tru",
+			expectedURL:         "http://localhost:8585/spec.yaml:tru",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "malformed bool with secret preserves URL",
+			input:               "http://localhost:8585/spec.yaml:tru:mysecret",
+			expectedURL:         "http://localhost:8585/spec.yaml:tru:mysecret",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "URL with path and no port",
+			input:               "https://raw.githubusercontent.com/org/repo/main/spec.yaml",
+			expectedURL:         "https://raw.githubusercontent.com/org/repo/main/spec.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "short URL without path",
+			input:               "http://localhost:true",
+			expectedURL:         "http://localhost",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, mainArtifact, secret := parseImportURLArg(tt.input)
+			assert.Equal(t, tt.expectedURL, url)
+			assert.Equal(t, tt.expectedMainArtifact, mainArtifact)
+			assert.Equal(t, tt.expectedSecret, secret)
+		})
+	}
+}


### PR DESCRIPTION
Both the `import` and `import-url` commands accept a `:true` or `:false` suffix to mark an artifact as primary or secondary. If that suffix is malformed (e.g. `:tru` or `:xyz`), `strconv.ParseBool` returns `false` as its zero value — and that `false` was being unconditionally assigned to `mainArtifact`, silently overriding the intended default of `true`.

In practice this means a typo in the boolean flag would cause Microcks to treat the artifact as secondary when the user almost certainly meant it as primary. No clear error, just wrong behavior.

The fix is the same in both files: only assign `mainArtifact` when `ParseBool` succeeds. On failure, print a clear warning and keep the default value of `true`.

**Files changed:**

- `cmd/import.go` — replaced the outer `var err error` + direct assignment with a scoped `val` variable inside an if/else block. The `mainArtifact = val` assignment now only runs when parsing succeeds.
- `cmd/importURL.go` — same pattern: moved `mainArtifact = val` inside an `else` block so it only fires on success. Also replaced the raw `fmt.Println(err)` with a clearer warning message matching the style already used in `import.go`.

**Verification:**

```
go build ./...  — passes
go vet ./...   — no new issues
go test ./...  — all tests pass (1 pre-existing failure in TestDeleteContext, unrelated)
```

Signed-off-by: Adesh Deshmukh <adeshkd123@gmail.com>