### PR TITLE
fix(stop): add --name flag to stop named contexts and instances

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -11,11 +11,17 @@ import (
 )
 
 func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
+	var name string
 
 	var stopCmd = &cobra.Command{
 		Use:   "stop",
 		Short: "stop microcks instance",
 		Long:  "stop microcks instance",
+		Example: `# Stop the instance from the current context
+microcks stop
+
+# Stop by context name or instance name
+microcks stop --name myinstance`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			configFile := globalClientOpts.ConfigPath
@@ -27,8 +33,27 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				return
 			}
 
-			ctx, err := localConfig.ResolveContext("")
-			errors.CheckError(err)
+			var ctx *config.Context
+			if name != "" {
+				ctx, err = localConfig.ResolveContext(name)
+				if err != nil {
+					var ctxRef *config.ContextRef
+					for _, c := range localConfig.Contexts {
+						if c.Instance == name {
+							ctxRef = &c
+							break
+						}
+					}
+					if ctxRef == nil {
+						log.Fatalf("No context found for '%s'", name)
+					}
+					ctx, err = localConfig.ResolveContext(ctxRef.Name)
+					errors.CheckError(err)
+				}
+			} else {
+				ctx, err = localConfig.ResolveContext("")
+				errors.CheckError(err)
+			}
 			instance := ctx.Instance
 
 			if instance.Name == "" {
@@ -72,6 +97,8 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			errors.CheckError(err)
 		},
 	}
+
+	stopCmd.Flags().StringVar(&name, "name", "", "Name of the context or instance to stop (uses current context if empty)")
 
 	return stopCmd
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -38,9 +38,9 @@ microcks stop --name myinstance`,
 				ctx, err = localConfig.ResolveContext(name)
 				if err != nil {
 					var ctxRef *config.ContextRef
-					for _, c := range localConfig.Contexts {
-						if c.Instance == name {
-							ctxRef = &c
+					for i := range localConfig.Contexts {
+						if localConfig.Contexts[i].Instance == name {
+							ctxRef = &localConfig.Contexts[i]
 							break
 						}
 					}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -35,25 +35,11 @@ microcks stop --name myinstance`,
 
 			var ctx *config.Context
 			if name != "" {
-				ctx, err = localConfig.ResolveContext(name)
-				if err != nil {
-					var ctxRef *config.ContextRef
-					for i := range localConfig.Contexts {
-						if localConfig.Contexts[i].Instance == name {
-							ctxRef = &localConfig.Contexts[i]
-							break
-						}
-					}
-					if ctxRef == nil {
-						log.Fatalf("No context found for '%s'", name)
-					}
-					ctx, err = localConfig.ResolveContext(ctxRef.Name)
-					errors.CheckError(err)
-				}
+				ctx, err = resolveStopTarget(name, localConfig)
 			} else {
 				ctx, err = localConfig.ResolveContext("")
-				errors.CheckError(err)
 			}
+			errors.CheckError(err)
 			instance := ctx.Instance
 
 			if instance.Name == "" {
@@ -101,4 +87,21 @@ microcks stop --name myinstance`,
 	stopCmd.Flags().StringVar(&name, "name", "", "Name of the context or instance to stop (uses current context if empty)")
 
 	return stopCmd
+}
+
+// resolveStopTarget resolves a stop target by name.
+// Context name is checked first because it is the explicit user-assigned
+// identifier. Instance name is a secondary label (from start --name) —
+// used as fallback when no context with the given name exists.
+func resolveStopTarget(name string, cfg *config.LocalConfig) (*config.Context, error) {
+	ctx, err := cfg.ResolveContext(name)
+	if err == nil {
+		return ctx, nil
+	}
+	for i := range cfg.Contexts {
+		if cfg.Contexts[i].Instance == name {
+			return cfg.ResolveContext(cfg.Contexts[i].Name)
+		}
+	}
+	return nil, fmt.Errorf("no context found for '%s'", name)
 }

--- a/cmd/stop_test.go
+++ b/cmd/stop_test.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/microcks/microcks-cli/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveStopTargetByContextName(t *testing.T) {
+	cfg := &config.LocalConfig{
+		Contexts: []config.ContextRef{
+			{Name: "dev", Server: "http://dev-server:8080", User: "u1"},
+		},
+		Servers: []config.Server{
+			{Server: "http://dev-server:8080"},
+		},
+		Users: []config.User{
+			{Name: "u1"},
+		},
+	}
+
+	ctx, err := resolveStopTarget("dev", cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "dev", ctx.Name)
+}
+
+func TestResolveStopTargetByInstanceName(t *testing.T) {
+	cfg := &config.LocalConfig{
+		Contexts: []config.ContextRef{
+			{Name: "http://server", Server: "http://instance-server:8080", User: "u1", Instance: "myinst"},
+		},
+		Servers: []config.Server{
+			{Server: "http://instance-server:8080"},
+		},
+		Users: []config.User{
+			{Name: "u1"},
+		},
+	}
+
+	ctx, err := resolveStopTarget("myinst", cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "http://server", ctx.Name)
+}
+
+func TestResolveStopTargetNotFound(t *testing.T) {
+	cfg := &config.LocalConfig{
+		Contexts: []config.ContextRef{
+			{Name: "dev", Server: "http://dev-server:8080", User: "u1"},
+		},
+		Servers: []config.Server{
+			{Server: "http://dev-server:8080"},
+		},
+		Users: []config.User{
+			{Name: "u1"},
+		},
+	}
+
+	_, err := resolveStopTarget("nonexistent", cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestResolveStopTargetCollisionContextWins(t *testing.T) {
+	cfg := &config.LocalConfig{
+		Contexts: []config.ContextRef{
+			{Name: "shared", Server: "http://server-a:8080", User: "u1", Instance: "other"},
+			{Name: "different", Server: "http://server-b:8080", User: "u2", Instance: "shared"},
+		},
+		Servers: []config.Server{
+			{Server: "http://server-a:8080"},
+			{Server: "http://server-b:8080"},
+		},
+		Users: []config.User{
+			{Name: "u1"},
+			{Name: "u2"},
+		},
+	}
+
+	ctx, err := resolveStopTarget("shared", cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "shared", ctx.Name)
+	assert.Equal(t, "http://server-a:8080", ctx.Server.Server)
+}
+
+func TestResolveStopTargetEmptyName(t *testing.T) {
+	cfg := &config.LocalConfig{
+		CurrentContext: "dev",
+		Contexts: []config.ContextRef{
+			{Name: "dev", Server: "http://dev-server:8080", User: "u1"},
+		},
+		Servers: []config.Server{
+			{Server: "http://dev-server:8080"},
+		},
+		Users: []config.User{
+			{Name: "u1"},
+		},
+	}
+
+	ctx, err := resolveStopTarget("", cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "dev", ctx.Name)
+}


### PR DESCRIPTION
## Problem

The `microcks stop` command only supports stopping the instance associated with the *current context*. There is no way to target a specific instance by name — even though `microcks start --name <name>` and `microcks login --name <name>` already allow users to create named contexts and instances.

This asymmetry means that after starting multiple instances or logging into multiple servers, users have no direct way to stop a specific one without first switching context.

## Root Cause

When a user runs `microcks start --name myinstance`, the CLI stores the context with:
- **Context name** = `http://localhost:8585` (the server URL)
- **Instance field** = `myinstance` (the user-given name)

So a naive lookup by context name alone (`ResolveContext(myinstance)`) fails — there is no context literally named `myinstance`. The existing `ResolveContext` expects the context's *name* field, not the Instance field.

## Solution

This PR adds a `--name` flag to `microcks stop` with a **two-tier fallback resolution**:

1. **Try as a context name** — works for contexts created via `microcks login --name dev` (stored as `Context{Name: "dev"}`)
2. **Scan contexts by Instance field** — works for contexts created via `microcks start --name myinstance` (stored as `ContextRef{Name: "http://...", Instance: "myinstance"}`)

If neither lookup succeeds, the user receives a clear error message.

When `--name` is omitted, behavior is 100% identical to the current code (uses the current context).

## Changes

`cmd/stop.go` — 29 insertions, 2 deletions:
- Added `var name string` for the flag variable
- Added `Example` help text with usage patterns
- Added two-tier context resolution logic
- Registered the `--name` flag on `stopCmd`

## Verification

| Check | Result |
|-------|--------|
| `go build ./...` | ✅ Compiles cleanly |
| All existing tests | ✅ Pass (26/27 pass; TestDeleteContext failure is pre-existing) |
| Backward compatible | ✅ No flag = unchanged behavior |

## Example Usage

```bash
# Stop the instance from the current context (existing behavior)
microcks stop

# Stop by context name (useful after login --name)
microcks stop --name dev-context

# Stop by instance name (useful after start --name)
microcks stop --name myinstance
```

Fixes #438