### PR TITLE
fix (cmd,pkg) : Potential Panic/Crash via Nil Pointer Dereference in Switch Context Command

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -47,6 +47,7 @@ microcks context http://localhost:8080 --delete`,
 			}
 
 			ctxName := args[0]
+			errors.CheckConfigNil(localCfg == nil, configPath)
 			if localCfg.CurrentContext == ctxName {
 				fmt.Printf("Already at context '%s'\n", localCfg.CurrentContext)
 				return
@@ -100,9 +101,7 @@ func deleteContext(context, configPath string) error {
 func printMicrocksContexts(configPath string) {
 	localCfg, err := config.ReadLocalConfig(configPath)
 	errors.CheckError(err)
-	if localCfg == nil {
-		log.Fatalf("No contexts defined in %s", configPath)
-	}
+	errors.CheckConfigNil(localCfg == nil, configPath)
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	defer func() { _ = w.Flush() }()
 	columnNames := []string{"CURRENT", "NAME", "SERVER"}

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -64,3 +64,9 @@ func TestDeleteContext(t *testing.T) {
 	_, err = config.ReadLocalConfig(testConfigFilePath)
 	require.NoError(t, err)
 }
+
+func TestDeleteContextEmpty(t *testing.T) {
+	err := deleteContext("http://localhost:8080", "./testdata/non-existent-file.config")
+	require.EqualError(t, err, "Nothing to logout from")
+}
+

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -24,6 +24,13 @@ func CheckError(err error) {
 	}
 }
 
+func CheckConfigNil(isNil bool, path string) {
+	if isNil {
+		Fatal(ErrorGeneric, "No contexts defined in "+path)
+	}
+}
+
+
 // Fatal is a wrapper for log.Fatal() to exit with custom code
 func Fatal(exitcode int, args ...interface{}) {
 	log.Println(args...)


### PR DESCRIPTION


### Description
If a user runs the `context` command on a fresh installation without a pre-existing configuration, `config.ReadLocalConfig(...)` returns `nil, nil`. The command checks for errors but not for `nil` values, and proceeds directly to access `localCfg.CurrentContext`:
```go
localCfg, err := config.ReadLocalConfig(configPath)
errors.CheckError(err)
...
if localCfg.CurrentContext == ctxName {
```
This causes a runtime nil-pointer dereference panic.

### Reason 
Standard CLI usability dictates that commands should fail gracefully with a user-friendly message rather than panicking when no configuration is initialized.


<img width="843" height="386" alt="image" src="https://github.com/user-attachments/assets/ec7a73e2-dc4d-4a88-a79a-d11ea5ace19c" />

Closes #462 