### PR TITLE
fix (cmd) : URL Port Corrupts Input in Import-URL Command

### DIFF
--- a/cmd/importURL.go
+++ b/cmd/importURL.go
@@ -100,22 +100,7 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 				mainArtifact := true
 				secret := ""
 
-				// Check if URL starts with https or http
-				if strings.HasPrefix(f, "https://") || strings.HasPrefix(f, "http://") {
-					urlAndMainAtrifactAndSecretName := strings.Split(f, ":")
-					n := len(urlAndMainAtrifactAndSecretName)
-					f = urlAndMainAtrifactAndSecretName[0] + ":" + urlAndMainAtrifactAndSecretName[1]
-					if n > 2 {
-						val, err := strconv.ParseBool(urlAndMainAtrifactAndSecretName[2])
-						if err != nil {
-							fmt.Println(err)
-						}
-						mainArtifact = val
-					}
-					if n > 3 {
-						secret = urlAndMainAtrifactAndSecretName[3]
-					}
-				}
+				f, mainArtifact, secret = parseImportURLArg(f)
 
 				// Try downloading the artifcat
 				msg, err := mc.DownloadArtifact(f, mainArtifact, secret)
@@ -129,4 +114,27 @@ func NewImportURLCommand(globalClientOpts *connectors.ClientOptions) *cobra.Comm
 	}
 
 	return importURLCmd
+}
+
+func parseImportURLArg(f string) (string, bool, string) {
+	mainArtifact := true
+	secret := ""
+
+	// Check if URL starts with https or http
+	if strings.HasPrefix(f, "https://") || strings.HasPrefix(f, "http://") {
+		parts := strings.Split(f, ":")
+		n := len(parts)
+
+		for i := n - 1; i >= 2; i-- {
+			if val, parseErr := strconv.ParseBool(parts[i]); parseErr == nil {
+				mainArtifact = val
+				if i+1 < n {
+					secret = strings.Join(parts[i+1:], ":")
+				}
+				f = strings.Join(parts[:i], ":")
+				break
+			}
+		}
+	}
+	return f, mainArtifact, secret
 }

--- a/cmd/importURL_test.go
+++ b/cmd/importURL_test.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseImportURLArg(t *testing.T) {
+	tests := []struct {
+		name                string
+		input               string
+		expectedURL         string
+		expectedMainArtifact bool
+		expectedSecret      string
+	}{
+		{
+			name:                "standard URL without suffixes",
+			input:               "https://example.com/openapi.yaml",
+			expectedURL:         "https://example.com/openapi.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "standard URL with mainArtifact true",
+			input:               "https://example.com/spec1.yaml:true",
+			expectedURL:         "https://example.com/spec1.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "standard URL with mainArtifact false",
+			input:               "https://example.com/spec1.yaml:false",
+			expectedURL:         "https://example.com/spec1.yaml",
+			expectedMainArtifact: false,
+			expectedSecret:      "",
+		},
+		{
+			name:                "standard URL with mainArtifact and secret",
+			input:               "https://example.com/spec1.yaml:true:my-secret",
+			expectedURL:         "https://example.com/spec1.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "my-secret",
+		},
+		{
+			name:                "standard URL with mainArtifact false and secret",
+			input:               "https://example.com/spec1.yaml:false:my-secret-token",
+			expectedURL:         "https://example.com/spec1.yaml",
+			expectedMainArtifact: false,
+			expectedSecret:      "my-secret-token",
+		},
+		{
+			name:                "URL with port and no suffixes",
+			input:               "http://localhost:8585/spec.yaml",
+			expectedURL:         "http://localhost:8585/spec.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "URL with port and mainArtifact true",
+			input:               "http://localhost:8585/spec.yaml:true",
+			expectedURL:         "http://localhost:8585/spec.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "URL with port and mainArtifact false",
+			input:               "http://localhost:8585/spec.yaml:false",
+			expectedURL:         "http://localhost:8585/spec.yaml",
+			expectedMainArtifact: false,
+			expectedSecret:      "",
+		},
+		{
+			name:                "URL with port, mainArtifact and secret",
+			input:               "http://localhost:8585/spec.yaml:true:my-secret-token",
+			expectedURL:         "http://localhost:8585/spec.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "my-secret-token",
+		},
+		{
+			name:                "URL with port, mainArtifact false and secret",
+			input:               "http://localhost:8585/spec.yaml:false:my-secret-token",
+			expectedURL:         "http://localhost:8585/spec.yaml",
+			expectedMainArtifact: false,
+			expectedSecret:      "my-secret-token",
+		},
+		{
+			name:                "malformed bool suffix preserves URL",
+			input:               "http://localhost:8585/spec.yaml:tru",
+			expectedURL:         "http://localhost:8585/spec.yaml:tru",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "malformed bool with secret preserves URL",
+			input:               "http://localhost:8585/spec.yaml:tru:mysecret",
+			expectedURL:         "http://localhost:8585/spec.yaml:tru:mysecret",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "URL with path and no port",
+			input:               "https://raw.githubusercontent.com/org/repo/main/spec.yaml",
+			expectedURL:         "https://raw.githubusercontent.com/org/repo/main/spec.yaml",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+		{
+			name:                "short URL without path",
+			input:               "http://localhost:true",
+			expectedURL:         "http://localhost",
+			expectedMainArtifact: true,
+			expectedSecret:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, mainArtifact, secret := parseImportURLArg(tt.input)
+			assert.Equal(t, tt.expectedURL, url)
+			assert.Equal(t, tt.expectedMainArtifact, mainArtifact)
+			assert.Equal(t, tt.expectedSecret, secret)
+		})
+	}
+}


### PR DESCRIPTION
### Description
The `import-url` command parses arguments formatted as `url:primary:secret`. It uses `strings.Split(f, ":")` and reconstructs the URL by concatenating the first two elements. If the URL contains a port number (e.g. `http://localhost:8585/spec.yaml`), the split splits it into `["http", "//localhost", "8585/spec.yaml"]`. The code then drops the port and path, changing the URL to `http://localhost`.

### Reason Why It Is Valid
It breaks importing artifacts from local test instances or any custom web server that runs on a non-default port (containing a colon).

### Bug Simulation Workflow

```mermaid
graph TD
    A["User runs: microcks import-url http://localhost:8585/api.yaml"] --> B["Split by ':' produces http, //localhost, 8585/api.yaml"]
    B --> C["Reconstruction: urlAndMainAtrifactAndSecretName[0] + ':' + urlAndMainAtrifactAndSecretName[1]"]
    C --> D["Resulting URL is http://localhost"]
    D --> E["API import request sent to http://localhost instead of http://localhost:8585/api.yaml"]
```


### after fix:

- `importURL.go`
#### Replace the simple : splitting logic with a more robust parser that checks segments from the right end of the string to identify the optional main and secret parameters.

- [NEW] 
`importURL_test.go`
#### Add unit tests to verify the parsing logic for various URL combinations, including:

- Standard URLs (no port, no suffixes)
- URLs with ports (no suffixes)
- URLs with ports and main suffix
- URLs with ports, main suffix, and secret suffix
- Standard URLs with main and secret suffixes



Closes #463 
@lbroudoux @Harsh4902 
do checkout whenever you get time