### PR TITLE
fix: remove stale instance entry on recreate and guard stop against missing containers

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -66,8 +66,8 @@ microcks start --name [name of you container/instance]`,
 				errors.CheckError(err)
 				if !exists {
 					fmt.Printf("Container for instance %s no longer exists, recreating it\n", name)
+					localConfig.RemoveInstance(instance.ContainerID)
 					instance.Status = ""
-					instance.ContainerID = ""
 				}
 			}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -99,8 +99,9 @@ microcks start --name [name of you container/instance]`,
 					if _, err := fmt.Fprintf(progress, "Container for instance %s no longer exists, recreating it\n", name); err != nil {
 						return errors.Wrap(errors.KindEnvironment, err)
 					}
+
+					localConfig.RemoveInstance(instance.ContainerID)
 					instance.Status = ""
-					instance.ContainerID = ""
 				}
 			}
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -59,7 +59,7 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				_ = localConfig.RemoveServer(ctx.Server.Server)
 				_ = localConfig.RemoveUser(ctx.User.Name)
 				_ = localConfig.RemoveAuth(ctx.Server.Server)
-				_ = localConfig.RemoveInstance(instance.Name)
+				_ = localConfig.RemoveInstance(instance.ContainerID)
 
 				localConfig.CurrentContext = ""
 				log.Printf("Instance %s removed successfully", instance.Name)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -40,6 +40,14 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			errors.CheckError(err)
 			defer containerClient.CloseClient()
 
+			exists, _ := containerClient.ContainerExists(instance.ContainerID)
+			errors.CheckError(err)
+			if !exists {
+				fmt.Printf("Container for instance %s no longer exists\n", instance.Name)
+				fmt.Printf("Run 'microcks start --name %s' to bring the container back\n", instance.Name)
+				return
+			}
+
 			err = containerClient.StopContainer(instance.ContainerID)
 			if err != nil {
 				log.Fatalf("Failed to stop a container: %v", err)
@@ -59,7 +67,7 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				_ = localConfig.RemoveServer(ctx.Server.Server)
 				_ = localConfig.RemoveUser(ctx.User.Name)
 				_ = localConfig.RemoveAuth(ctx.Server.Server)
-				_ = localConfig.RemoveInstance(instance.ContainerID)
+				_ = localConfig.RemoveInstance(instance.Name)
 
 				localConfig.CurrentContext = ""
 				log.Printf("Instance %s removed successfully", instance.Name)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -40,7 +40,7 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			errors.CheckError(err)
 			defer containerClient.CloseClient()
 
-			exists, _ := containerClient.ContainerExists(instance.ContainerID)
+			exists, err := containerClient.ContainerExists(instance.ContainerID)
 			errors.CheckError(err)
 			if !exists {
 				fmt.Printf("Container for instance %s no longer exists\n", instance.Name)
@@ -67,7 +67,7 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				_ = localConfig.RemoveServer(ctx.Server.Server)
 				_ = localConfig.RemoveUser(ctx.User.Name)
 				_ = localConfig.RemoveAuth(ctx.Server.Server)
-				_ = localConfig.RemoveInstance(instance.Name)
+				_ = localConfig.RemoveInstance(instance.ContainerID)
 
 				localConfig.CurrentContext = ""
 				log.Printf("Instance %s removed successfully", instance.Name)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -62,6 +62,16 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 			}
 			defer containerClient.CloseClient()
 
+			exists, err := containerClient.ContainerExists(instance.ContainerID)
+			if err != nil {
+				return errors.Wrap(errors.KindEnvironment, err)
+			}
+			if !exists {
+				fmt.Printf("Container for instance %s no longer exists\n", instance.Name)
+				fmt.Printf("Run 'microcks start --name %s' to bring the container back\n", instance.Name)
+				return nil
+			}
+
 			if err := containerClient.StopContainer(instance.ContainerID); err != nil {
 				return errors.Wrap(errors.KindEnvironment, fmt.Errorf("failed to stop container: %w", err))
 			}
@@ -78,7 +88,7 @@ func NewStopCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command {
 				localConfig.RemoveServer(ctx.Server.Server)
 				localConfig.RemoveUser(ctx.User.Name)
 				localConfig.RemoveAuth(ctx.Server.Server)
-				localConfig.RemoveInstance(instance.Name)
+				localConfig.RemoveInstance(instance.ContainerID)
 
 				localConfig.CurrentContext = ""
 				log.Printf("Instance %s removed successfully", instance.Name)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -369,7 +369,7 @@ func TestLocalConfigCRUDAndValidation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "cont456", inst2Updated.ContainerID)
 
-	ok = loadedCfg.RemoveInstance("inst2-updated")
+	ok = loadedCfg.RemoveInstance("cont456")
 	assert.True(t, ok)
 
 	ok = loadedCfg.RemoveInstance("")

--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -321,12 +321,12 @@ func (l *LocalConfig) UpsertInstance(instance Instance) {
 }
 
 // Returns true if server was removed successfully
-func (l *LocalConfig) RemoveInstance(instanceName string) bool {
-	if instanceName == "" {
+func (l *LocalConfig) RemoveInstance(instanceID string) bool {
+	if instanceID == "" {
 		return true
 	}
 	for a, i := range l.Instances {
-		if i.Name == instanceName {
+		if i.ContainerID == instanceID {
 			l.Instances = append(l.Instances[:a], l.Instances[a+1:]...)
 			return true
 		}

--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -337,12 +337,12 @@ func (l *LocalConfig) UpsertInstance(instance Instance) {
 }
 
 // Returns true if server was removed successfully
-func (l *LocalConfig) RemoveInstance(instanceName string) bool {
-	if instanceName == "" {
+func (l *LocalConfig) RemoveInstance(instanceID string) bool {
+	if instanceID == "" {
 		return true
 	}
 	for a, i := range l.Instances {
-		if i.Name == instanceName {
+		if i.ContainerID == instanceID {
 			l.Instances = append(l.Instances[:a], l.Instances[a+1:]...)
 			return true
 		}

--- a/pkg/config/localconfig_test.go
+++ b/pkg/config/localconfig_test.go
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package config
 
 import (

--- a/pkg/config/localconfig_test.go
+++ b/pkg/config/localconfig_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestRemoveInstance_ByContainerID(t *testing.T) {
+	localConfig := &LocalConfig{
+		Instances: []Instance{
+			{Name: "microcks", ContainerID: "old-id-123", Status: "Running", Port: "8585"},
+			{Name: "staging", ContainerID: "staging-id-456", Status: "Running", Port: "8586"},
+		},
+	}
+
+	removed := localConfig.RemoveInstance("old-id-123")
+
+	if !removed {
+		t.Error("expected RemoveInstance to return true")
+	}
+	// staging should still be there
+	if len(localConfig.Instances) != 1 {
+		t.Errorf("expected 1 instance remaining, got %d", len(localConfig.Instances))
+	}
+	if localConfig.Instances[0].ContainerID != "staging-id-456" {
+		t.Errorf("expected staging instance to remain, got %s", localConfig.Instances[0].ContainerID)
+	}
+}
+
+func TestRemoveInstance_NoDuplicatesAfterRecreate(t *testing.T) {
+	localConfig := &LocalConfig{
+		Instances: []Instance{
+			{Name: "microcks", ContainerID: "old-id-123", Status: "Running", Port: "8585"},
+			{Name: "staging", ContainerID: "staging-id-456", Status: "Running", Port: "8586"},
+		},
+	}
+
+	localConfig.RemoveInstance("old-id-123")
+
+	localConfig.UpsertInstance(Instance{
+		Name:        "microcks",
+		ContainerID: "new-id-789",
+		Status:      "Running",
+		Port:        "8585",
+	})
+
+	// staging + recreated microcks = 2, no duplicates
+	if len(localConfig.Instances) != 2 {
+		t.Errorf("expected 2 instances, got %d — duplicate entries present", len(localConfig.Instances))
+	}
+	// verify microcks has new ID
+	for _, i := range localConfig.Instances {
+		if i.Name == "microcks" && i.ContainerID != "new-id-789" {
+			t.Errorf("expected new-id-789, got %s", i.ContainerID)
+		}
+	}
+}

--- a/pkg/config/localconfig_test.go
+++ b/pkg/config/localconfig_test.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package config
+
+import (
+	"testing"
+)
+
+func TestRemoveInstance_ByContainerID(t *testing.T) {
+	localConfig := &LocalConfig{
+		Instances: []Instance{
+			{Name: "microcks", ContainerID: "old-id-123", Status: "Running", Port: "8585"},
+			{Name: "staging", ContainerID: "staging-id-456", Status: "Running", Port: "8586"},
+		},
+	}
+
+	removed := localConfig.RemoveInstance("old-id-123")
+
+	if !removed {
+		t.Error("expected RemoveInstance to return true")
+	}
+	// staging should still be there
+	if len(localConfig.Instances) != 1 {
+		t.Errorf("expected 1 instance remaining, got %d", len(localConfig.Instances))
+	}
+	if localConfig.Instances[0].ContainerID != "staging-id-456" {
+		t.Errorf("expected staging instance to remain, got %s", localConfig.Instances[0].ContainerID)
+	}
+}
+
+func TestRemoveInstance_NoDuplicatesAfterRecreate(t *testing.T) {
+	localConfig := &LocalConfig{
+		Instances: []Instance{
+			{Name: "microcks", ContainerID: "old-id-123", Status: "Running", Port: "8585"},
+			{Name: "staging", ContainerID: "staging-id-456", Status: "Running", Port: "8586"},
+		},
+	}
+
+	localConfig.RemoveInstance("old-id-123")
+
+	localConfig.UpsertInstance(Instance{
+		Name:        "microcks",
+		ContainerID: "new-id-789",
+		Status:      "Running",
+		Port:        "8585",
+	})
+
+	// staging + recreated microcks = 2, no duplicates
+	if len(localConfig.Instances) != 2 {
+		t.Errorf("expected 2 instances, got %d — duplicate entries present", len(localConfig.Instances))
+	}
+	// verify microcks has new ID
+	for _, i := range localConfig.Instances {
+		if i.Name == "microcks" && i.ContainerID != "new-id-789" {
+			t.Errorf("expected new-id-789, got %s", i.ContainerID)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

When a container is removed externally (e.g. `docker system prune`) and
`microcks start` recreates it, the old instance entry was never removed from
config  causing duplicate instance records to accumulate on every recreate.

Two root causes:
1. `RemoveInstance` matched by `Name` (not unique) instead of `ContainerID` (unique)
2. The `autoRemove` path in `stop.go` was passing `instance.Name` to `RemoveInstance`,
   silently failing to remove the correct entry
3. `start.go` was clearing `instance.ContainerID = ""` instead of calling
   `RemoveInstance` to actually remove the stale record from config

## Changes

- `cmd/start.go`: call `localConfig.RemoveInstance(instance.ContainerID)` to
  remove the stale record before recreating, instead of just clearing the local variable
- `cmd/stop.go`: pass `instance.ContainerID` to `RemoveInstance` in the `autoRemove` path
- `pkg/config/localconfig.go`: `RemoveInstance` now matches by `ContainerID` instead of `Name`

## Testing

Ran `docker rm <container>` while config shows `status: Running`, then
`microcks start --name <instance>` config shows a single clean entry with
the new container ID, no duplicates.

Realted: https://github.com/microcks/microcks-cli/pull/456

Fix: https://github.com/microcks/microcks-cli/issues/483