### PR TITLE
fix(watcher): skip context when Microcks client cannot be created

### DIFF
--- a/pkg/watcher/executor.go
+++ b/pkg/watcher/executor.go
@@ -33,6 +33,7 @@ func TriggerImport(entry config.WatchEntry) {
 			mc, err = connectors.NewClient(*globalClientOpts)
 			if err != nil {
 				fmt.Printf("[ERROR] Cannot connect to Microcks client: %v in context '%s'\n", err, context)
+				continue
 			}
 		} else {
 			// We have no config file, so just create a client with context as server URL.

--- a/pkg/watcher/executor_test.go
+++ b/pkg/watcher/executor_test.go
@@ -1,0 +1,37 @@
+package watcher
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/microcks/microcks-cli/pkg/config"
+)
+
+// TestTriggerImportSkipsContextWhenClientFails ensures TriggerImport does not
+// panic when the Microcks client cannot be created for a context (for example
+// an unknown or unresolvable context). Before the fix it dereferenced a nil
+// client and crashed the watcher process.
+func TestTriggerImportSkipsContextWhenClientFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Write an empty local config so that resolving any context fails and
+	// NewClient returns a nil client with an error.
+	cfgDir := path.Join(home, ".config", "microcks")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	if err := os.WriteFile(path.Join(cfgDir, "config"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	entry := config.WatchEntry{
+		FilePath:     path.Join(home, "spec.json"),
+		Context:      []string{"missing-context"},
+		MainArtifact: true,
+	}
+
+	// Should return cleanly instead of panicking on a nil client.
+	TriggerImport(entry)
+}


### PR DESCRIPTION
## Problem

In `TriggerImport`, when `connectors.NewClient` fails it logs the error but
keeps going, so the code reaches `mc.UploadArtifact` with a nil client and the
watcher process panics with a nil pointer dereference (#475). This happens for
example when a watch entry references a context that cannot be resolved.

## Fix

`continue` to the next context after logging the connection error, so a failed
context is skipped instead of crashing the daemon.

Added a regression test in `pkg/watcher` that drives `TriggerImport` with an
unresolvable context; it panics without the change and passes with it.

Fixes #475
