### PR TITLE
fix(cli): classify failures and partial de-panic in the client library

### DIFF
--- a/pkg/connectors/keycloak_client.go
+++ b/pkg/connectors/keycloak_client.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/microcks/microcks-cli/pkg/config"
+	"github.com/microcks/microcks-cli/pkg/errors"
 	"golang.org/x/oauth2"
 )
 
@@ -45,12 +46,12 @@ type keycloakClient struct {
 }
 
 // NewKeycloakClient build a new KeycloakClient implementation
-func NewKeycloakClient(realmURL string, username string, password string) KeycloakClient {
+func NewKeycloakClient(realmURL string, username string, password string) (KeycloakClient, error) {
 	kc := keycloakClient{}
 
 	u, err := url.Parse(realmURL)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(errors.KindUsage, fmt.Errorf("invalid Keycloak URL %q: %w", realmURL, err))
 	}
 	kc.BaseURL = u
 	kc.Username = username
@@ -65,7 +66,7 @@ func NewKeycloakClient(realmURL string, username string, password string) Keyclo
 	} else {
 		kc.httpClient = http.DefaultClient
 	}
-	return &kc
+	return &kc, nil
 }
 
 // ConnectAndGetToken implementation on keycloakClient structure
@@ -88,7 +89,7 @@ func (c *keycloakClient) ConnectAndGetToken() (string, error) {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(errors.KindConnection, err)
 	}
 	defer resp.Body.Close()
 
@@ -97,16 +98,23 @@ func (c *keycloakClient) ConnectAndGetToken() (string, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", errors.Wrap(errors.KindConnection, fmt.Errorf("reading Keycloak token response: %w", err))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.Wrapf(errors.KindAPI, "Keycloak returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var openIDResp map[string]interface{}
 	if err := json.Unmarshal(body, &openIDResp); err != nil {
-		panic(err)
+		return "", errors.Wrap(errors.KindAPI, fmt.Errorf("parsing Keycloak token response: %w", err))
 	}
 
-	accessToken := openIDResp["access_token"].(string)
-	return accessToken, err
+	accessToken, ok := openIDResp["access_token"].(string)
+	if !ok || accessToken == "" {
+		return "", errors.Wrapf(errors.KindAPI, "Keycloak token response missing access_token")
+	}
+	return accessToken, nil
 }
 
 func (c *keycloakClient) GetOIDCConfig() (*oauth2.Config, error) {
@@ -116,27 +124,34 @@ func (c *keycloakClient) GetOIDCConfig() (*oauth2.Config, error) {
 	// Create HTTP request
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
-		fmt.Println("Error creating request:", err)
+		return nil, errors.Wrap(errors.KindGeneric, fmt.Errorf("creating Keycloak OIDC request: %w", err))
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(errors.KindConnection, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return nil, errors.Wrap(errors.KindConnection, fmt.Errorf("reading Keycloak OIDC config: %w", err))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Wrapf(errors.KindAPI, "Keycloak returned HTTP %d for OIDC config: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var openIDResp map[string]interface{}
 	if err := json.Unmarshal(body, &openIDResp); err != nil {
-		panic(err)
+		return nil, errors.Wrap(errors.KindAPI, fmt.Errorf("parsing Keycloak OIDC config: %w", err))
 	}
 
-	authURL := openIDResp["authorization_endpoint"].(string)
-	tokenURL := openIDResp["token_endpoint"].(string)
+	authURL, _ := openIDResp["authorization_endpoint"].(string)
+	tokenURL, _ := openIDResp["token_endpoint"].(string)
+	if authURL == "" || tokenURL == "" {
+		return nil, errors.Wrapf(errors.KindAPI, "Keycloak OIDC config missing authorization_endpoint or token_endpoint")
+	}
 
 	return &oauth2.Config{
 		Endpoint: oauth2.Endpoint{
@@ -160,7 +175,7 @@ func (c *keycloakClient) ConnectAndGetTokenAndRefreshToken(username, password st
 	// Create HTTP request
 	req, err := http.NewRequest("POST", u.String(), bytes.NewBufferString(data.Encode()))
 	if err != nil {
-		fmt.Println("Error creating request:", err)
+		return "", "", errors.Wrap(errors.KindGeneric, fmt.Errorf("creating Keycloak token request: %w", err))
 	}
 
 	// Set headers
@@ -168,22 +183,29 @@ func (c *keycloakClient) ConnectAndGetTokenAndRefreshToken(username, password st
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", "", err
+		return "", "", errors.Wrap(errors.KindConnection, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", "", errors.Wrap(errors.KindConnection, fmt.Errorf("reading Keycloak token response: %w", err))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", errors.Wrapf(errors.KindAPI, "Keycloak returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var openIDResp map[string]interface{}
 	if err := json.Unmarshal(body, &openIDResp); err != nil {
-		panic(err)
+		return "", "", errors.Wrap(errors.KindAPI, fmt.Errorf("parsing Keycloak token response: %w", err))
 	}
 
-	authToken := openIDResp["access_token"].(string)
-	refreshToken := openIDResp["refresh_token"].(string)
+	authToken, _ := openIDResp["access_token"].(string)
+	refreshToken, _ := openIDResp["refresh_token"].(string)
+	if authToken == "" || refreshToken == "" {
+		return "", "", errors.Wrapf(errors.KindAPI, "Keycloak token response missing access_token or refresh_token")
+	}
 
 	return authToken, refreshToken, nil
 }

--- a/pkg/connectors/keycloak_client.go
+++ b/pkg/connectors/keycloak_client.go
@@ -46,12 +46,14 @@ type keycloakClient struct {
 }
 
 // NewKeycloakClient build a new KeycloakClient implementation
-func NewKeycloakClient(realmURL string, username string, password string) (KeycloakClient, error) {
+func NewKeycloakClient(realmURL string, username string, password string) KeycloakClient {
 	kc := keycloakClient{}
 
 	u, err := url.Parse(realmURL)
 	if err != nil {
-		return nil, errors.Wrap(errors.KindUsage, fmt.Errorf("invalid Keycloak URL %q: %w", realmURL, err))
+		// url.Parse only fails on a malformed URL; returning it needs a
+		// signature change, done with the RunE command migration.
+		panic(err)
 	}
 	kc.BaseURL = u
 	kc.Username = username
@@ -66,7 +68,7 @@ func NewKeycloakClient(realmURL string, username string, password string) (Keycl
 	} else {
 		kc.httpClient = http.DefaultClient
 	}
-	return &kc, nil
+	return &kc
 }
 
 // ConnectAndGetToken implementation on keycloakClient structure

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -151,7 +151,7 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 
 		u, err := url.Parse(apiURL)
 		if err != nil {
-			panic(err)
+			return nil, errors.Wrap(errors.KindUsage, fmt.Errorf("invalid server URL %q: %w", apiURL, err))
 		}
 		c.APIURL = u
 
@@ -182,7 +182,7 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 }
 
 // NewMicrocksClient builds a new headless MicrocksClient without any authtoken and all for general purposes
-func NewMicrocksClient(apiURL string) MicrocksClient {
+func NewMicrocksClient(apiURL string) (MicrocksClient, error) {
 	mc := microcksClient{}
 
 	if strings.HasSuffix(apiURL, "/api") {
@@ -194,7 +194,7 @@ func NewMicrocksClient(apiURL string) MicrocksClient {
 
 	u, err := url.Parse(apiURL)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(errors.KindUsage, fmt.Errorf("invalid server URL %q: %w", apiURL, err))
 	}
 	mc.APIURL = u
 
@@ -207,7 +207,7 @@ func NewMicrocksClient(apiURL string) MicrocksClient {
 	} else {
 		mc.httpClient = http.DefaultClient
 	}
-	return &mc
+	return &mc, nil
 }
 func (c *microcksClient) HttpClient() *http.Client {
 	return c.httpClient
@@ -230,7 +230,7 @@ func (c *microcksClient) GetKeycloakURL() (string, error) {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(errors.KindConnection, err)
 	}
 	defer resp.Body.Close()
 
@@ -239,24 +239,29 @@ func (c *microcksClient) GetKeycloakURL() (string, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", errors.Wrap(errors.KindConnection, fmt.Errorf("reading Keycloak config response: %w", err))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.Wrapf(errors.KindAPI, "Microcks returned HTTP %d for Keycloak config: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var configResp map[string]interface{}
 	if err := json.Unmarshal(body, &configResp); err != nil {
-		panic(err)
+		return "", errors.Wrap(errors.KindAPI, fmt.Errorf("parsing Keycloak config response: %w", err))
 	}
 
-	// Retrieve auth server url and realm name.
-	enabled := configResp["enabled"].(bool)
-	authServerURL := configResp["auth-server-url"].(string)
-	realmName := configResp["realm"].(string)
-
-	// Return a proper URL or 'null' if Keycloak is disables.
-	if enabled {
-		return authServerURL + "/realms/" + realmName + "/", nil
+	// Return 'null' if Keycloak is disabled.
+	if enabled, _ := configResp["enabled"].(bool); !enabled {
+		return "null", nil
 	}
-	return "null", nil
+
+	authServerURL, _ := configResp["auth-server-url"].(string)
+	realmName, _ := configResp["realm"].(string)
+	if authServerURL == "" || realmName == "" {
+		return "", errors.Wrapf(errors.KindAPI, "Keycloak config response missing auth-server-url or realm")
+	}
+	return authServerURL + "/realms/" + realmName + "/", nil
 }
 
 func (c *microcksClient) refreshAuthToken(localCfg *config.LocalConfig, ctxName, configPath string) error {
@@ -304,10 +309,17 @@ func (c *microcksClient) refreshAuthToken(localCfg *config.LocalConfig, ctxName,
 
 func (c *microcksClient) redeemRefreshToken(auth config.Auth) (string, string, error) {
 	keyCloakUrl, err := c.GetKeycloakURL()
-	errors.CheckError(err)
-	kc := NewKeycloakClient(keyCloakUrl, "", "")
+	if err != nil {
+		return "", "", err
+	}
+	kc, err := NewKeycloakClient(keyCloakUrl, "", "")
+	if err != nil {
+		return "", "", err
+	}
 	oauth2Conf, err := kc.GetOIDCConfig()
-	errors.CheckError(err)
+	if err != nil {
+		return "", "", err
+	}
 	oauth2Conf.ClientID = auth.ClientId
 	oauth2Conf.ClientSecret = auth.ClientSecret
 
@@ -372,18 +384,22 @@ func (c *microcksClient) CreateTestResult(serviceID string, testEndpoint string,
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(errors.KindConnection, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %w", err)
+		return "", errors.Wrap(errors.KindConnection, fmt.Errorf("reading test creation response: %w", err))
 	}
 
 	// Check HTTP status before attempting to parse.
 	if resp.StatusCode != 201 {
-		return "", fmt.Errorf("microcks returned HTTP %d: %s (is the service '%s' registered?)", resp.StatusCode, strings.TrimSpace(string(body)), serviceID)
+		kind := errors.KindAPI
+		if resp.StatusCode == http.StatusNotFound {
+			kind = errors.KindNotFound
+		}
+		return "", errors.Wrapf(kind, "Microcks returned HTTP %d: %s (is the service '%s' registered?)", resp.StatusCode, strings.TrimSpace(string(body)), serviceID)
 	}
 
 	var createTestResp map[string]interface{}
@@ -416,7 +432,7 @@ func (c *microcksClient) GetTestResult(testResultID string) (*TestResultSummary,
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(errors.KindConnection, err)
 	}
 	defer resp.Body.Close()
 
@@ -425,7 +441,7 @@ func (c *microcksClient) GetTestResult(testResultID string) (*TestResultSummary,
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return nil, errors.Wrap(errors.KindConnection, fmt.Errorf("reading test result response: %w", err))
 	}
 
 	result := TestResultSummary{}
@@ -440,7 +456,7 @@ func (c *microcksClient) UploadArtifact(specificationFilePath string, mainArtifa
 	// Ensure file exists on fs.
 	file, err := os.Open(specificationFilePath)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(errors.KindUsage, fmt.Errorf("cannot read artifact %q: %w", specificationFilePath, err))
 	}
 	defer file.Close()
 
@@ -490,7 +506,7 @@ func (c *microcksClient) UploadArtifact(specificationFilePath string, mainArtifa
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(errors.KindConnection, err)
 	}
 	defer resp.Body.Close()
 
@@ -509,7 +525,7 @@ func (c *microcksClient) UploadArtifact(specificationFilePath string, mainArtifa
 
 	// Raise exception if not created.
 	if resp.StatusCode != 201 {
-		return "", errs.New(string(respBody))
+		return "", errors.Wrap(errors.KindAPI, errs.New(strings.TrimSpace(string(respBody))))
 	}
 
 	return string(respBody), nil
@@ -549,7 +565,7 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(errors.KindConnection, err)
 	}
 	defer resp.Body.Close()
 
@@ -558,15 +574,15 @@ func (c *microcksClient) DownloadArtifact(artifactURL string, mainArtifact bool,
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err.Error())
+		return "", errors.Wrap(errors.KindConnection, fmt.Errorf("reading download response: %w", err))
 	}
 
 	// Raise exception if not created.
 	if resp.StatusCode != 201 {
-		return "", errs.New(string(respBody))
+		return "", errors.Wrap(errors.KindAPI, errs.New(strings.TrimSpace(string(respBody))))
 	}
 
-	return string(respBody), err
+	return string(respBody), nil
 }
 
 func ensureValidOperationsList(filteredOperations string) bool {

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -182,7 +182,7 @@ func NewClient(opts ClientOptions) (MicrocksClient, error) {
 }
 
 // NewMicrocksClient builds a new headless MicrocksClient without any authtoken and all for general purposes
-func NewMicrocksClient(apiURL string) (MicrocksClient, error) {
+func NewMicrocksClient(apiURL string) MicrocksClient {
 	mc := microcksClient{}
 
 	if strings.HasSuffix(apiURL, "/api") {
@@ -194,7 +194,9 @@ func NewMicrocksClient(apiURL string) (MicrocksClient, error) {
 
 	u, err := url.Parse(apiURL)
 	if err != nil {
-		return nil, errors.Wrap(errors.KindUsage, fmt.Errorf("invalid server URL %q: %w", apiURL, err))
+		// url.Parse only fails on a malformed URL; returning it needs a
+		// signature change, done with the RunE command migration.
+		panic(err)
 	}
 	mc.APIURL = u
 
@@ -207,7 +209,7 @@ func NewMicrocksClient(apiURL string) (MicrocksClient, error) {
 	} else {
 		mc.httpClient = http.DefaultClient
 	}
-	return &mc, nil
+	return &mc
 }
 func (c *microcksClient) HttpClient() *http.Client {
 	return c.httpClient
@@ -312,10 +314,7 @@ func (c *microcksClient) redeemRefreshToken(auth config.Auth) (string, string, e
 	if err != nil {
 		return "", "", err
 	}
-	kc, err := NewKeycloakClient(keyCloakUrl, "", "")
-	if err != nil {
-		return "", "", err
-	}
+	kc := NewKeycloakClient(keyCloakUrl, "", "")
 	oauth2Conf, err := kc.GetOIDCConfig()
 	if err != nil {
 		return "", "", err

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package errors
 
 import (

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -1,10 +1,16 @@
 package errors
 
 import (
+	stderrors "errors"
+	"fmt"
 	"log"
 	"os"
 )
 
+// Deprecated: these numeric codes and the Check*/Fatal helpers below are the
+// legacy exit mechanism. New code classifies failures with a Kind (see Wrap) and
+// lets cmd.Handle map Kind -> exit code. Kept as a shim until every call site is
+// migrated, then removed.
 const (
 	// ErrorCommandSpecific is reserved for command specific indications
 	ErrorCommandSpecific = 1
@@ -18,23 +24,84 @@ const (
 	ErrorGeneric = 20
 )
 
+// Deprecated: return errors.Wrap(kind, err) from a RunE command instead.
 func CheckError(err error) {
 	if err != nil {
 		Fatal(ErrorGeneric, err)
 	}
 }
 
+// Deprecated: return a KindNotFound-wrapped error instead.
 func CheckConfigNil(isNil bool, path string) {
 	if isNil {
 		Fatal(ErrorGeneric, "No contexts defined in "+path)
 	}
 }
 
-
-// Fatal is a wrapper for log.Fatal() to exit with custom code
+// Deprecated: only main/cmd.Handle should exit the process. Fatal is a wrapper
+// for log.Fatal() to exit with a custom code.
 func Fatal(exitcode int, args ...interface{}) {
 	log.Println(args...)
 	os.Exit(exitcode)
 }
 
+// Kind classifies why an operation failed. The library returns kinds; the cmd
+// layer maps them to exit codes, so pkg/* never depends on exit codes and stays
+// safe to embed.
+type Kind int
 
+const (
+	// KindGeneric is an unclassified failure. It is the zero value, so an
+	// unwrapped error is treated as generic.
+	KindGeneric Kind = iota
+	// KindUsage is a bad argument or flag supplied by the user.
+	KindUsage
+	// KindConnection is a failure to reach the Microcks or Keycloak endpoint.
+	KindConnection
+	// KindAPI is a server that rejected the request or returned an unusable response.
+	KindAPI
+	// KindNotFound is a requested remote resource that does not exist.
+	KindNotFound
+	// KindEnvironment is a local precondition not met — container runtime down,
+	// image unpullable, or ephemeral server not ready. Not KindConnection, which
+	// is about reaching the Microcks server.
+	KindEnvironment
+)
+
+// KindError wraps an error with a Failure Kind.
+type KindError struct {
+	Kind Kind
+	Err  error
+}
+
+func (e *KindError) Error() string { return e.Err.Error() }
+func (e *KindError) Unwrap() error { return e.Err }
+
+// Wrap tags err with a Failure Kind. It returns nil when err is nil, so it is
+// safe to write `return errors.Wrap(KindAPI, doThing())`.
+func Wrap(kind Kind, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &KindError{Kind: kind, Err: err}
+}
+
+// Wrapf builds a kind-tagged error from a format string.
+func Wrapf(kind Kind, format string, a ...any) error {
+	return &KindError{Kind: kind, Err: fmt.Errorf(format, a...)}
+}
+
+// KindOf reports the Failure Kind carried by err's chain, defaulting to
+// KindGeneric when none is present (including when err is nil).
+func KindOf(err error) Kind {
+	var ke *KindError
+	if stderrors.As(err, &ke) {
+		return ke.Kind
+	}
+	return KindGeneric
+}
+
+// ErrTestFailed signals a completed test run whose result does not conform to the
+// contract. It is not a failure to *run*: the command has already rendered the
+// result, so the CLI exits non-zero without printing this sentinel. See cmd.Handle.
+var ErrTestFailed = stderrors.New("contract test failed")

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -1,0 +1,41 @@
+package errors
+
+import (
+	stderrors "errors"
+	"fmt"
+	"testing"
+)
+
+func TestWrapNilReturnsNil(t *testing.T) {
+	if Wrap(KindAPI, nil) != nil {
+		t.Fatal("Wrap of a nil error should return nil")
+	}
+}
+
+func TestKindOf(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want Kind
+	}{
+		{"nil", nil, KindGeneric},
+		{"plain error", stderrors.New("boom"), KindGeneric},
+		{"wrapped", Wrap(KindConnection, stderrors.New("refused")), KindConnection},
+		{"wrapped again", fmt.Errorf("outer: %w", Wrap(KindNotFound, stderrors.New("404"))), KindNotFound},
+	}
+	for _, c := range cases {
+		if got := KindOf(c.err); got != c.want {
+			t.Errorf("%s: KindOf = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestWrapfPreservesKindAndMessage(t *testing.T) {
+	err := Wrapf(KindEnvironment, "docker unreachable on attempt %d", 2)
+	if KindOf(err) != KindEnvironment {
+		t.Errorf("KindOf = %v, want KindEnvironment", KindOf(err))
+	}
+	if got := err.Error(); got != "docker unreachable on attempt 2" {
+		t.Errorf("Error() = %q", got)
+	}
+}

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -1,4 +1,20 @@
-package errors
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package errors
 
 import (
 	stderrors "errors"

--- a/pkg/watcher/watchManager.go
+++ b/pkg/watcher/watchManager.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/microcks/microcks-cli/pkg/config"
-	"github.com/microcks/microcks-cli/pkg/errors"
 )
 
 type WatchManager struct {
@@ -88,7 +87,9 @@ func (wm *WatchManager) Run() {
 					err := wm.Reload()
 					wm.lock.Unlock()
 					if err != nil {
-						errors.CheckError(err)
+						// A bad config edit shouldn't kill the watcher; log and
+						// keep the previous config until the next valid save.
+						log.Printf("[ERROR] Config reload failed, keeping previous config: %v", err)
 					}
 				} else {
 					wm.lock.Lock()


### PR DESCRIPTION
Part of the Microcks CLI v2 work https://github.com/microcks/microcks-cli/issues/255.

Introduces a small **Failure Kind** vocabulary in `pkg/errors` (`Kind`, `Wrap`/`Wrapf`, `KindOf`, and an `ErrTestFailed` sentinel) and makes the client library **return classified errors instead of panicking or exiting**.

### Why
`pkg/connectors` and `keycloak_client` previously `panic`'d on runtime errors (bad response body, unreachable server). A library that can take down its host process is unsafe to embed, which the planned VS Code extension needs to do. Kinds are the library's vocabulary; exit codes stay a CLI concern (added in next PR ()), so `pkg/*` never depends on them.

### Notable
Fixes two real latent bugs found while de-panicking:
- Keycloak swallowed request-creation errors: nil-pointer dereference.
- Unchecked `openIDResp["access_token"].(string)`:  **the CLI crashed on a Keycloak 401** instead of reporting it.

### Scope / safety
Additive and **non-breaking**: the legacy `CheckError`/`Fatal` shim and the existing constructor signatures are untouched here (removed/changed in later PRs). Build + tests green.
