### PR TITLE
fix: handle StringFromCharset against empty charset and add Unit test for rand package

### DIFF
--- a/pkg/util/rand/rand.go
+++ b/pkg/util/rand/rand.go
@@ -15,6 +15,9 @@ func String(n int) (string, error) {
 
 // StringFromCharset generates, from a given charset, a cryptographically-secure pseudo-random string of a given length.
 func StringFromCharset(n int, charset string) (string, error) {
+	if n > 0 && len(charset) == 0 {
+		return "", fmt.Errorf("charset must not be empty when n > 0")
+	}
 	b := make([]byte, n)
 	maxIdx := big.NewInt(int64(len(charset)))
 	for i := 0; i < n; i++ {
@@ -22,7 +25,6 @@ func StringFromCharset(n int, charset string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("failed to generate random string: %w", err)
 		}
-		// randIdx is necessarily safe to convert to int, because the max came from an int.
 		randIdxInt := int(randIdx.Int64())
 		b[i] = charset[randIdxInt]
 	}

--- a/pkg/util/rand/rand.go
+++ b/pkg/util/rand/rand.go
@@ -15,6 +15,9 @@ func String(n int) (string, error) {
 
 // StringFromCharset generates, from a given charset, a cryptographically-secure pseudo-random string of a given length.
 func StringFromCharset(n int, charset string) (string, error) {
+	if n<0{
+		return "", fmt.Errorf("n must be greater than 0")
+	}
 	if n > 0 && len(charset) == 0 {
 		return "", fmt.Errorf("charset must not be empty when n > 0")
 	}

--- a/pkg/util/rand/rand_test.go
+++ b/pkg/util/rand/rand_test.go
@@ -1,0 +1,114 @@
+package rand
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{name: "zero length", length: 0},
+		{name: "single character", length: 1},
+		{name: "short string", length: 8},
+		{name: "longer string", length: 32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := String(tt.length)
+			if err != nil {
+				t.Fatalf("String(%d) returned error: %v", tt.length, err)
+			}
+			if len(got) != tt.length {
+				t.Fatalf("String(%d) length = %d, want %d", tt.length, len(got), tt.length)
+			}
+			for i := 0; i < len(got); i++ {
+				if !strings.Contains(letterBytes, string(got[i])) {
+					t.Fatalf("String(%d) contains invalid character %q at index %d", tt.length, got[i], i)
+				}
+			}
+		})
+	}
+}
+
+func TestStringProducesDifferentValues(t *testing.T) {
+	t.Parallel()
+
+	const length = 32
+
+	first, err := String(length)
+	if err != nil {
+		t.Fatalf("first String(%d) returned error: %v", length, err)
+	}
+
+	second, err := String(length)
+	if err != nil {
+		t.Fatalf("second String(%d) returned error: %v", length, err)
+	}
+
+	if first == second {
+		t.Fatalf("expected two generated strings to differ, both were %q", first)
+	}
+}
+
+func TestStringFromCharset(t *testing.T) {
+	t.Parallel()
+
+	const charset = "01"
+
+	got, err := StringFromCharset(16, charset)
+	if err != nil {
+		t.Fatalf("StringFromCharset returned error: %v", err)
+	}
+	if len(got) != 16 {
+		t.Fatalf("StringFromCharset length = %d, want 16", len(got))
+	}
+	for i := 0; i < len(got); i++ {
+		if !strings.Contains(charset, string(got[i])) {
+			t.Fatalf("StringFromCharset contains invalid character %q at index %d", got[i], i)
+		}
+	}
+}
+
+func TestStringFromCharsetZeroLength(t *testing.T) {
+	t.Parallel()
+
+	got, err := StringFromCharset(0, "abc")
+	if err != nil {
+		t.Fatalf("StringFromCharset(0) returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("StringFromCharset(0) = %q, want empty string", got)
+	}
+}
+
+func TestStringFromCharsetSingleCharacter(t *testing.T) {
+	t.Parallel()
+
+	got, err := StringFromCharset(10, "x")
+	if err != nil {
+		t.Fatalf("StringFromCharset returned error: %v", err)
+	}
+	if got != "xxxxxxxxxx" {
+		t.Fatalf("StringFromCharset with single-character charset = %q, want %q", got, "xxxxxxxxxx")
+	}
+}
+
+func TestStringFromCharsetEmptyCharset(t *testing.T) {
+	t.Parallel()
+
+	got, err := StringFromCharset(5, "")
+	if err == nil {
+		t.Fatal("StringFromCharset with empty charset expected error, got nil")
+	}
+	if got != "" {
+		t.Fatalf("StringFromCharset with empty charset = %q, want empty string on error", got)
+	}
+}

--- a/pkg/util/rand/rand_test.go
+++ b/pkg/util/rand/rand_test.go
@@ -38,23 +38,23 @@ func TestString(t *testing.T) {
 	}
 }
 
-func TestStringProducesDifferentValues(t *testing.T) {
+func TestStringRepeatedCalls(t *testing.T) {
 	t.Parallel()
 
-	const length = 32
+	
+	const (
+		length = 32
+		attempts=5
+	)
 
-	first, err := String(length)
-	if err != nil {
-		t.Fatalf("first String(%d) returned error: %v", length, err)
-	}
-
-	second, err := String(length)
-	if err != nil {
-		t.Fatalf("second String(%d) returned error: %v", length, err)
-	}
-
-	if first == second {
-		t.Fatalf("expected two generated strings to differ, both were %q", first)
+	for i := 0; i < attempts; i++ {
+		got, err := String(length)
+		if err != nil {
+			t.Fatalf("String(%d) returned error on attempt %d: %v", length, i, err)
+		}
+		if len(got) != length {
+			t.Fatalf("String(%d) length on attempt %d = %d, want %d", length, i, len(got), length)
+		}
 	}
 }
 

--- a/pkg/util/rand/rand_test.go
+++ b/pkg/util/rand/rand_test.go
@@ -47,7 +47,15 @@ func TestStringRepeatedCalls(t *testing.T) {
 		attempts=5
 	)
 
-	for i := 0; i < attempts; i++ {
+	first, err := String(length)
+ 	if err != nil {
+ 		t.Fatalf("String(%d) returned error on attempt 0: %v", length, err)
+ 	}
+ 	if len(first) != length {
+ 		t.Fatalf("String(%d) length on attempt 0 = %d, want %d", length, len(first), length)
+ 	}
+ 	allSame := true
+ 	for i := 1; i < attempts; i++ {
 		got, err := String(length)
 		if err != nil {
 			t.Fatalf("String(%d) returned error on attempt %d: %v", length, i, err)
@@ -55,8 +63,15 @@ func TestStringRepeatedCalls(t *testing.T) {
 		if len(got) != length {
 			t.Fatalf("String(%d) length on attempt %d = %d, want %d", length, i, len(got), length)
 		}
+		if got != first {
+			allSame = false
+		}
 	}
-}
+		if allSame {
+			t.Fatalf("String(%d) returned the same value for %d consecutive calls; expected at least one differing result", length, attempts)
+		}
+	}
+
 
 func TestStringFromCharset(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What
Fixes a panic in `StringFromCharset(n, charset)` — it panicked with `crypto/rand: argument to Int is <= 0` when called with an empty charset and `n > 0`, instead of returning an error the way its other failure paths already do. Also adds the first unit test coverage for `pkg/util/rand`, which previously had none.

## Why
Closes #493 

## Changes
- `pkg/util/rand/rand.go`: guard against an empty charset before calling `crypto/rand.Int`, returning a descriptive error instead of panicking.
- `pkg/util/rand/rand_test.go`: table-driven tests for `String` and `StringFromCharset`, covering:
  - output length matches requested length across zero/single/short/long inputs
  - output characters all belong to the supplied/default charset
  - two calls with identical parameters produce different output
  - single-character charset behavior
  - empty-charset behavior — the case that previously panicked and now correctly returns an error

## Testing
- `go test ./pkg/util/rand/... -v` — all cases pass, including the previously-panicking empty-charset case.
- `go test ./...` — full suite passes.
<img width="942" height="800" alt="Screenshot 2026-07-25 222139" src="https://github.com/user-attachments/assets/7cb77e01-1189-4cad-8763-fe98ff1a21eb" />


## Notes
No behavior change for any existing valid input — `String()` and existing callers of `StringFromCharset()` with a non-empty charset are unaffected. This only changes behavior for the previously-panicking empty-charset edge case, and adds coverage that didn't exist before.