### PR TITLE
The watcher daemon crashes with a stack trace instead of handling the connection/context resolution failure gracefully.

### DIFF
--- a/pkg/watcher/executor.go
+++ b/pkg/watcher/executor.go
@@ -33,6 +33,7 @@ func TriggerImport(entry config.WatchEntry) {
 			mc, err = connectors.NewClient(*globalClientOpts)
 			if err != nil {
 				fmt.Printf("[ERROR] Cannot connect to Microcks client: %v in context '%s'\n", err, context)
+				continue
 			}
 		} else {
 			// We have no config file, so just create a client with context as server URL.

--- a/pkg/watcher/executor_test.go
+++ b/pkg/watcher/executor_test.go
@@ -1,0 +1,74 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microcks/microcks-cli/pkg/config"
+)
+
+func TestTriggerImport_NewClientErrorNoPanic(t *testing.T) {
+	// Create a temp directory for the config dir.
+	tmpDir := t.TempDir()
+
+	// Set MICROCKS_CONFIG_DIR env var to point to our temp directory
+	os.Setenv("MICROCKS_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("MICROCKS_CONFIG_DIR")
+
+	// We create an invalid config file that fails validation or context resolution.
+	// This will cause connectors.NewClient to fail when resolving config context.
+	configPath := filepath.Join(tmpDir, "config")
+	invalidYAML := []byte(`
+currentContext: non-existent-context
+contexts:
+  - name: invalid
+`)
+	if err := os.WriteFile(configPath, invalidYAML, 0600); err != nil {
+		t.Fatalf("failed to write invalid config file: %v", err)
+	}
+
+	// TriggerImport should run and log the failure but not panic.
+	entry := config.WatchEntry{
+		FilePath:     "dummy.yaml",
+		MainArtifact: true,
+		Context:      []string{"non-existent-context"},
+	}
+
+	// Wrap in recover to assert no panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("TriggerImport panicked: %v", r)
+		}
+	}()
+
+	TriggerImport(entry)
+}
+
+func TestTriggerImport_NoConfigFile_NewMicrocksClientErrorNoPanic(t *testing.T) {
+	// Create a temp directory for the config dir to ensure config doesn't exist.
+	tmpDir := t.TempDir()
+
+	// Set MICROCKS_CONFIG_DIR env var to point to our empty temp directory.
+	os.Setenv("MICROCKS_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("MICROCKS_CONFIG_DIR")
+
+	// Since there is no config file in the temp directory, TriggerImport will fall back
+	// to creating a headless client via connectors.NewMicrocksClient(context).
+	// We pass a context containing a control character, which causes url.Parse to fail,
+	// ensuring NewMicrocksClient returns an error and does not panic.
+	entry := config.WatchEntry{
+		FilePath:     "dummy.yaml",
+		MainArtifact: true,
+		Context:      []string{"http://\x7f.com"},
+	}
+
+	// Wrap in recover to assert no panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("TriggerImport panicked: %v", r)
+		}
+	}()
+
+	TriggerImport(entry)
+}


### PR DESCRIPTION
Closes #475 
### Describe the bug

### Diagram
```mermaid
sequenceDiagram
    participant Watcher
    participant Executor
    participant Client as connectors.NewClient
    Watcher->>Executor: TriggerImport(entry)
    Executor->>Client: NewClient(*globalClientOpts)
    Note over Client: Fails (e.g. invalid context)
    Client-->>Executor: nil, err
    Note over Executor: Logs error, but DOES NOT return!
    Executor->>Executor: mc.UploadArtifact(entry.FilePath, entry.MainArtifact)
    Note over Executor: Panic: nil pointer dereference (mc is nil)
```


### Description
In `pkg/watcher/executor.go`, the `TriggerImport` function instantiates the Microcks client using `connectors.NewClient`. If this fails (e.g., due to an invalid context or server address), it prints an error message but continues execution instead of returning early. It subsequently calls `mc.UploadArtifact()`, causing a nil pointer dereference panic.

### Impact
The watcher daemon crashes with a stack trace instead of handling the connection/context resolution failure gracefully.


### Steps to Reproduce
1. Configure a watch entry with an invalid or expired context.
2. Modify the watched file to trigger an fsnotify event.
3. The watch manager invokes `TriggerImport`, which prints `[ERROR] Cannot connect to Microcks client...` and immediately panics with a segmentation fault.

---