### PR TITLE
build: add nfpms config to generate deb and rpm packages

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,6 +32,18 @@ brews:
       owner: microcks
       name: homebrew-tap
 
+nfpms:
+  - id: microcks
+    package_name: microcks
+    vendor: Microcks
+    maintainer: Microcks <info@microcks.io>
+    description: CLI for Microcks.
+    homepage: https://github.com/microcks/microcks-cli
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+
 sboms:
   - artifacts: archive
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR addresses issue #153 by configuring GoReleaser to automatically build native Linux packages (`.deb` and `.rpm`). 
- Currently, Linux users must manually download the raw binary via `curl` and move it to their executable path. By adding the `nfpms` block to our `.goreleaser.yaml`, we now generate official `.deb` (Debian/Ubuntu) and `.rpm` (RedHat/CentOS) packages alongside our existing release artifacts.
- Added `nfpms` block below the `brews` block in `.goreleaser.yaml`.
### Next Steps & Discussion
This PR provides the raw packages, which users can now download and install via `sudo dpkg -i microcks.deb`. 
To fully achieve the `apt-get install microcks` experience requested in the issue, we will need to host these packages in an APT repository. I highly recommend using **Gemfury**, as it provides a free tier for OSS and integrates natively with GoReleaser. Once we have a Gemfury organization account set up, we can easily add the `fury` publisher block in a follow-up PR or update in this PR!

**Ref:**
- nFPM: https://goreleaser.com/customization/package/nfpm/
- GemFury: https://goreleaser.com/customization/publish/gemfury/

### Related issue(s)
Fixes #153
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->