### PR TITLE
docs: fix small typos

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -56,7 +56,7 @@ func NewLoginCommand(globalClientOpts *connectors.ClientOptions) *cobra.Command 
 		Use:   "login SERVER",
 		Short: "Login into Microcks instance",
 		Long:  "Login into Microcks instance",
-		Example: `microcks login http://locahost:8080
+		Example: `microcks login http://localhost:8080
 
 # Provide name to your logged in context (Default context name is server name)
 microcks login http://localhost:8080 --name

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -50,10 +50,10 @@ microcks start
 microcks start --port [Port you want]
 
 # Define your driver (by default docker)
-microcks start --driver [driver you wnat either 'docker' or 'podman']
+microcks start --driver [driver you want either 'docker' or 'podman']
 
 # Define name of your microcks container/instance
-microcks start --name [name of you container/instance]`,
+microcks start --name [name of your container/instance]`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !output.IsTextOrJSON(outputFormat) {
 				return errors.Wrapf(errors.KindUsage, "--output must be one of: text, json")

--- a/documentation/cmd/login.md
+++ b/documentation/cmd/login.md
@@ -4,7 +4,7 @@ Log in to a Microcks instance using username/password or SSO. Creates or updates
 ### Examples
 ```bash
 # Login to microcks using a username and password
-microcks login http://locahost:8080
+microcks login http://localhost:8080
 
 # Provide name to your logged in context (Default context name is server name)
 microcks login http://localhost:8080 --name

--- a/documentation/cmd/start.md
+++ b/documentation/cmd/start.md
@@ -18,7 +18,7 @@ microcks start --port [Port you want]
 microcks start --driver [docker-or-podman]
 
 # Define name of your microcks container/instance
-microcks start --name [name of you container/instance]
+microcks start --name [name of your container/instance]
 
 # Auto remove the container on exit
 microcks start --rm

--- a/pkg/config/localconfig.go
+++ b/pkg/config/localconfig.go
@@ -361,7 +361,7 @@ func (l *LocalConfig) GetAuth(server string) (*Auth, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("Auth for '%s' is undifined", server)
+	return nil, fmt.Errorf("Auth for '%s' is undefined", server)
 }
 
 func (l *LocalConfig) UpsertAuth(auth Auth) {

--- a/pkg/connectors/keycloak_client.go
+++ b/pkg/connectors/keycloak_client.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// KeycloakClient defines methods for cinteracting with Keycloak
+// KeycloakClient defines methods for interacting with Keycloak
 type KeycloakClient interface {
 	ConnectAndGetToken() (string, error)
 	ConnectAndGetTokenAndRefreshToken(string, string) (string, string, error)

--- a/pkg/connectors/microcks_client.go
+++ b/pkg/connectors/microcks_client.go
@@ -273,7 +273,7 @@ func (c *microcksClient) HttpClient() *http.Client {
 }
 
 func (c *microcksClient) GetKeycloakURL() (string, error) {
-	// Ensure we have a correct URL for retrieving Keycloal configuration.
+	// Ensure we have a correct URL for retrieving Keycloak configuration.
 	rel := &url.URL{Path: "keycloak/config"}
 	u := c.APIURL.ResolveReference(rel)
 


### PR DESCRIPTION
Closes #292

Fixes command examples, docs, comments, and an error message:
- `locahost` -> `localhost`
- `wnat` -> `want`
- `name of you` -> `name of your`
- `undifined` -> `undefined`
- `cinteracting` -> `interacting`
- `Keycloal` -> `Keycloak`

Verified with `go test ./pkg/config ./pkg/connectors ./cmd`.